### PR TITLE
Fix script loading when Redix fail to evaluate

### DIFF
--- a/lib/verk.ex
+++ b/lib/verk.ex
@@ -12,13 +12,7 @@ defmodule Verk do
   alias Verk.Job
 
   @doc false
-  def start(_type, _args) do
-    redis_url = Application.get_env(:verk, :redis_url, "redis://127.0.0.1:6379")
-    { :ok, redis } = Redix.start_link(redis_url)
-    Verk.Scripts.load(redis)
-    :ok = Redix.stop(redis)
-    Verk.Supervisor.start_link
-  end
+  def start(_type, _args), do: Verk.Supervisor.start_link
 
   @doc """
   Add a new `queue` with a pool of size `size` of workers


### PR DESCRIPTION
It fixes https://github.com/edgurgel/verk/issues/4

We can check if `Redix.Error` happens instead of a normal connection error `(:closed)`