### PR TITLE
Move to erlang 18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: elixir
 elixir:
-  - 1.1.1
   - 1.2.0
 otp_release:
   - 18.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: elixir
 elixir:
-  - 1.0.5
   - 1.1.1
+  - 1.2.0
 otp_release:
-  - 17.5
+  - 18.2
 script:
   - MIX_ENV=test mix test --no-start --trace
 after_script:

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Verk.Mixfile do
   defp deps do
     [{ :redix, "~> 0.3.3" },
      { :poison, "~> 1.5" },
-     { :timex, "~> 0.19" },
+     { :timex, "~> 1.0" },
      { :poolboy, "~> 1.5.1" },
      { :earmark, "~> 0.1.17", only: :docs },
      { :ex_doc, "~> 0.8.0", only: :docs },

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"certifi": {:hex, :certifi, "0.3.0"},
-  "combine": {:hex, :combine, "0.5.2"},
+  "combine": {:hex, :combine, "0.7.0"},
   "connection": {:hex, :connection, "1.0.2"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.8.4"},
@@ -14,5 +14,5 @@
   "poolboy": {:hex, :poolboy, "1.5.1"},
   "redix": {:hex, :redix, "0.3.3"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "timex": {:hex, :timex, "0.19.2"},
-  "tzdata": {:hex, :tzdata, "0.1.7"}}
+  "timex": {:hex, :timex, "1.0.0"},
+  "tzdata": {:hex, :tzdata, "0.5.6"}}


### PR DESCRIPTION
We will need `:ets:update_counter/4` for the new `Verk.QueueStats` #soon

Elixir 1.1 was removed from Travis as it's failing with some crazy error: https://travis-ci.org/edgurgel/verk/jobs/103509836

Upgraded to timex `~> 1.0` as well