### PR TITLE
Add queue stats

### DIFF
--- a/lib/verk/queue_stats.ex
+++ b/lib/verk/queue_stats.ex
@@ -1,0 +1,48 @@
+defmodule Verk.QueueStats do
+  @moduledoc """
+  This process will update an :ets table with the following information per queue
+
+    * Current amount of running jobs
+    * Amount of finished jobs
+    * Amount of failed jobs
+
+  The saved tuples are of this form:
+  { queue_name, running_jobs_counter, finished_jobs_counter, failed_jobs_counter }
+  """
+  use GenEvent
+
+  @table :queue_stats
+
+  @doc """
+  Lists the queues and their stats
+  """
+  def all do
+    for { queue, running, finished, failed } <- :ets.tab2list(@table) do
+      %{ queue: queue, running_counter: running, finished_counter: finished, failed_counter: failed }
+    end
+  end
+
+  @doc false
+  def init(_) do
+    :ets.new(@table, [:ordered_set, :named_table, read_concurrency: true, keypos: 1])
+    { :ok, nil }
+  end
+
+  @doc false
+  def handle_event(%Verk.Events.JobStarted{ job: job }, state) do
+    :ets.update_counter(@table, job.queue, { 2, 1 }, default_tuple(job.queue))
+    { :ok, state }
+  end
+
+  def handle_event(%Verk.Events.JobFinished{ job: job }, state) do
+    :ets.update_counter(@table, job.queue, [{ 3, 1 }, { 2, -1 }], default_tuple(job.queue))
+    { :ok, state }
+  end
+
+  def handle_event(%Verk.Events.JobFailed{ job: job }, state) do
+    :ets.update_counter(@table, job.queue, [{ 4, 1 }, { 2, -1 }], default_tuple(job.queue))
+    { :ok, state }
+  end
+
+  defp default_tuple(queue), do: { queue, 0, 0, 0 }
+end

--- a/lib/verk/queue_stats_watcher.ex
+++ b/lib/verk/queue_stats_watcher.ex
@@ -1,0 +1,44 @@
+defmodule Verk.QueueStatsWatcher do
+  @moduledoc """
+  This process will watch the event handler QueueStats
+
+  Inspired by Elixir's Logger.Watcher
+  """
+  use GenServer
+  require Logger
+
+  @doc false
+  def start_link, do: GenServer.start_link(__MODULE__, [], [])
+
+  @doc false
+  def init(_) do
+    Logger.info("Starting QueueStats handler to keep track of the work done by each queue")
+    ref = Process.monitor(Verk.EventManager)
+    :ok = GenEvent.add_mon_handler(Verk.EventManager, Verk.QueueStats, [])
+    { :ok, ref }
+  end
+
+  @doc false
+  def handle_info({ :gen_event_EXIT, _handler, reason }, ref) when reason in [:normal, :shutdown] do
+    { :stop, reason, ref }
+  end
+
+  def handle_info({ :gen_event_EXIT, handler, reason }, ref) do
+    Logger.error "GenEvent handler #{inspect handler}\n** (exit) #{format_exit(reason)}"
+
+    { :stop, reason, ref }
+  end
+
+  def handle_info({ :DOWN, ref, _, _, reason }, ref) do
+    Logger.error "QueueStats handler\n** (exit) #{format_exit(reason)}"
+
+    { :stop, reason, ref }
+  end
+
+  def handle_info(_msg, state) do
+    { :noreply, state }
+  end
+
+  defp format_exit({:EXIT, reason}), do: Exception.format_exit(reason)
+  defp format_exit(reason), do: Exception.format_exit(reason)
+end

--- a/lib/verk/supervisor.ex
+++ b/lib/verk/supervisor.ex
@@ -11,10 +11,11 @@ defmodule Verk.Supervisor do
     queues = Application.get_env(:verk, :queues, [])
     children = for { queue, size } <- queues, do: queue_child(queue, size)
 
-    schedule_manager = worker(Verk.ScheduleManager, [], id: :schedule_manager)
+    schedule_manager    = worker(Verk.ScheduleManager, [], id: :schedule_manager)
     verk_event_manager  = worker(GenEvent, [[name: Verk.EventManager]])
+    queue_stats_watcher = worker(Verk.QueueStatsWatcher, [])
 
-    children = [verk_event_manager | [schedule_manager | children]]
+    children = [verk_event_manager | [queue_stats_watcher | [schedule_manager | children]]]
     supervise(children, strategy: :one_for_one)
   end
 

--- a/test/queue_stats_test.exs
+++ b/test/queue_stats_test.exs
@@ -1,0 +1,61 @@
+defmodule Verk.QueueStatsTest do
+  use ExUnit.Case
+  import Verk.QueueStats
+
+  @table :queue_stats
+
+  test "init creates an ETS table" do
+    assert :ets.info(@table) == :undefined
+
+    assert init([]) == { :ok, nil }
+
+    assert :ets.info(@table) != :undefined
+  end
+
+  test "handle_event with started event" do
+    init([]) # create table
+    event = %Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue" } }
+
+    assert handle_event(event, :state) == { :ok, :state }
+
+    assert :ets.tab2list(@table) == [{"queue", 1, 0, 0}]
+  end
+
+  test "handle_event with finished event" do
+    init([]) # create table
+    event = %Verk.Events.JobFinished{ job: %Verk.Job{ queue: "queue" } }
+
+    assert handle_event(event, :state) == { :ok, :state }
+
+    assert :ets.tab2list(@table) == [{"queue", -1, 1, 0}]
+  end
+
+  test "handle_event with failed event" do
+    init([]) # create table
+    event = %Verk.Events.JobFailed{ job: %Verk.Job{ queue: "queue" } }
+
+    assert handle_event(event, :state) == { :ok, :state }
+
+    assert :ets.tab2list(@table) == [{"queue", -1, 0, 1}]
+  end
+
+  test "all with no data" do
+    init([]) # create table
+
+    assert all == []
+  end
+
+  test "all with different events happening" do
+    init([]) # create table
+
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_2" } }, :state)
+    handle_event(%Verk.Events.JobFinished{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobFailed{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+
+    assert all == [%{ queue: "queue_1", running_counter: 1, finished_counter: 1, failed_counter: 1 },
+                   %{ queue: "queue_2", running_counter: 1, finished_counter: 0, failed_counter: 0 } ]
+  end
+end

--- a/test/queue_stats_watcher_test.exs
+++ b/test/queue_stats_watcher_test.exs
@@ -1,0 +1,22 @@
+defmodule Verk.QueueStatsWatcherTest do
+  use ExUnit.Case
+  import Verk.QueueStatsWatcher
+
+  test "init adds monitored handler" do
+    { :ok, _pid } = GenEvent.start_link([name: Verk.EventManager])
+
+    assert { :ok, _ref } = init([])
+    assert { :monitors, process: { Verk.EventManager, _node } } = Process.info(self, :monitors)
+    assert GenEvent.which_handlers(Verk.EventManager) == [Verk.QueueStats]
+  end
+
+  test "handle_info :gen_event_EXIT stops watcher" do
+    assert handle_info({ :gen_event_EXIT, :handler, :normal}, :ref) == { :stop, :normal, :ref }
+    assert handle_info({ :gen_event_EXIT, :handler, :shutdown}, :ref) == { :stop, :shutdown, :ref }
+    assert handle_info({ :gen_event_EXIT, :handler, :crash}, :ref) == { :stop, :crash, :ref }
+  end
+
+  test "handle_info DOWN from manager stops watcher" do
+    assert handle_info({ :DOWN, :ref, :process, :pid, :reason}, :ref) == { :stop, :reason, :ref }
+  end
+end


### PR DESCRIPTION
`Verk.QueueStats` event handler will keep track of the work done by each queue:

* Running jobs counter
* Failed jobs counter
* Finished jobs counter

This can in the near future be used to store data related to amount of
jobs done inside Redis. It can from time to time increment the stats.

A Watcher was created to keep monitoring the handler as it's started by the GenEvent manager. More info: 

https://github.com/elixir-lang/elixir/blob/master/lib/logger/lib/logger/watcher.ex