### PR TITLE
Change WorkersManager handle_info to handle normal worker shutdown

### DIFF
--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -84,6 +84,10 @@ defmodule Verk.WorkersManager do
     end
   end
 
+  # The worker died normally after finishing the job. Message :done will come soon
+  # or already came. This case here is just to discard the message if it comes with :normal
+  def handle_info({ :DOWN, _mref, _worker, :normal }, state), do: { :noreply, state }
+
   def handle_info({ :DOWN, mref, _, worker, { reason, stack } }, state) do
     Logger.debug "Worker got down, reason: #{inspect reason}, #{inspect([mref, worker])}"
     case :ets.match(state.monitors, {worker, :'_', :'$1', mref, :'$2'}) do

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -148,7 +148,7 @@ defmodule Verk.WorkersManagerTest do
     assert validate [:poolboy, Verk.QueueManager]
   end
 
-  test "handle info DOWN coming from dead worker", %{ monitors: monitors } do
+  test "handle info DOWN coming from dead worker with reason and stacktrace", %{ monitors: monitors } do
     ref = make_ref
     worker = self
     pool_name = "pool_name"
@@ -174,6 +174,10 @@ defmodule Verk.WorkersManagerTest do
                                            exception: ^exception }
 
     assert validate [:poolboy, Verk.Log, Verk.QueueManager]
+  end
+
+  test "handle info DOWN coming from dead worker with normal reason" do
+    assert handle_info({ :DOWN, :_, :_, :normal }, :state) == { :noreply, :state }
   end
 
   test "cast failed coming from worker", %{ monitors: monitors } do


### PR DESCRIPTION
The monitored worker may die before the :done message is processed.

The manager will ignore a `:normal` reason of death as this is expected when the worker finishes its job.