### PR TITLE
Use a set for dead jobs

### DIFF
--- a/lib/verk/dead_set.ex
+++ b/lib/verk/dead_set.ex
@@ -1,0 +1,54 @@
+defmodule Verk.DeadSet do
+  @moduledoc """
+  This module interacts with jobs in the dead set
+  """
+  alias Verk.SortedSet
+  alias Verk.Job
+
+  @max_jobs 100
+  @timeout 60 * 60 * 24 * 7 # a week
+
+  @dead_key "dead"
+
+  @doc "Redis dead set key"
+  def key, do: @dead_key
+
+  def add(job, timestamp, redis \\ Verk.Redis) do
+    case Redix.pipeline(redis, [["ZADD", @dead_key, timestamp, Poison.encode!(job)],
+                                ["ZREMRANGEBYSCORE", @dead_key, "-inf", timestamp - @timeout],
+                                ["ZREMRANGEBYRANK", @dead_key, 0, -@max_jobs]]) do
+      { :ok, _ } -> :ok
+      error -> error
+    end
+  end
+
+  @doc """
+  Counts how many jobs are inside the dead set
+  """
+  @spec count(GenServer.Server) :: integer
+  def count(redis \\ Verk.Redis), do: SortedSet.count(@dead_key, redis)
+
+  @doc """
+  Clears the dead set
+  """
+  @spec clear(GenServer.server) :: boolean
+  def clear(redis \\ Verk.Redis), do: SortedSet.clear(@dead_key, redis)
+
+  @doc """
+  List jobs from `start` to `stop`
+  """
+  @spec range(integer, integer, GenServer.server) :: [Verk.Job.T]
+  def range(start \\ 0, stop \\ -1, redis \\ Verk.Redis) do
+    SortedSet.range(@dead_key, start, stop, redis)
+  end
+
+  @doc """
+  Delete the job from the dead set
+  """
+  @spec delete_job(%Job{} | String.t, GenServer.server) :: boolean
+  def delete_job(original_json, redis \\ Verk.Redis)
+  def delete_job(%Job{ original_json: original_json }, redis) do
+    delete_job(original_json, redis)
+  end
+  def delete_job(original_json, redis), do: SortedSet.delete_job(@dead_key, original_json, redis)
+end

--- a/test/dead_set_test.exs
+++ b/test/dead_set_test.exs
@@ -1,0 +1,91 @@
+defmodule Verk.DeadSetTest do
+  use ExUnit.Case
+  alias Verk.SortedSet
+  import Verk.DeadSet
+  import :meck
+
+  setup do
+    { :ok, redis } = Application.fetch_env!(:verk, :redis_url) |> Redix.start_link
+    Redix.command!(redis, ~w(DEL dead))
+    on_exit fn -> unload end
+    { :ok, %{ redis: redis } }
+  end
+
+  test "add/3", %{ redis: redis } do
+    job = %Verk.Job{ retry_count: 1 }
+    payload = Poison.encode!(job)
+    failed_at = 1
+
+    assert add(job, failed_at, redis) == :ok
+
+    assert Redix.command!(redis, ["ZRANGE", key, 0, -1, "WITHSCORES"]) == [payload, to_string(failed_at)]
+  end
+
+  test "add/3 remove old jobs", %{ redis: redis } do
+    job1 = %Verk.Job{ retry_count: 1 }
+    payload1 = Poison.encode!(job1)
+    job2 = %Verk.Job{ retry_count: 2 }
+    payload2 = Poison.encode!(job2)
+    failed_at = 60 * 60 * 24 * 7
+
+    assert add(job1, failed_at + 1, redis) == :ok
+    assert add(job2, failed_at + 2, redis) == :ok
+
+    assert Redix.command!(redis, ["ZRANGE", key, 0, 2, "WITHSCORES"])
+      == [payload1, to_string(failed_at + 1), payload2, to_string(failed_at + 2)]
+  end
+
+  test "count" do
+    expect(SortedSet, :count, [key, Verk.Redis], 1)
+
+    assert count == 1
+    assert validate SortedSet
+  end
+
+  test "clear" do
+    expect(SortedSet, :clear, [key, Verk.Redis], true)
+
+    assert clear
+    assert validate SortedSet
+  end
+
+  test "range" do
+    job = %Verk.Job{class: "Class", args: []}
+    json = Poison.encode!(job)
+
+    expect(SortedSet, :range, [key, 0, -1, Verk.Redis], [%{ job | original_json: json }])
+
+    assert range == [%{ job | original_json: json }]
+    assert validate SortedSet
+  end
+
+  test "range with start and stop" do
+    job = %Verk.Job{class: "Class", args: []}
+    json = Poison.encode!(job)
+
+    expect(SortedSet, :range, [key, 1, 2, Verk.Redis], [%{ job | original_json: json }])
+
+    assert range(1, 2) == [%{ job | original_json: json }]
+    assert validate SortedSet
+  end
+
+
+  test "delete_job having job with original_json" do
+    job = %Verk.Job{class: "Class", args: []}
+    json = Poison.encode!(job)
+    job = %{ job | original_json: json }
+
+    expect(SortedSet, :delete_job, [key, json, Verk.Redis], true)
+
+    assert delete_job(job) == true
+    assert validate SortedSet
+  end
+
+  test "delete_job with original_json" do
+    json = %Verk.Job{class: "Class", args: []} |> Poison.encode!
+    expect(SortedSet, :delete_job, [key, json, Verk.Redis], true)
+
+    assert delete_job(json) == true
+    assert validate SortedSet
+  end
+end

--- a/test/retry_set_test.exs
+++ b/test/retry_set_test.exs
@@ -10,6 +10,18 @@ defmodule Verk.RetrySetTest do
     :ok
   end
 
+  test "add" do
+    job = %Verk.Job{ retry_count: 1 }
+    failed_at = 1
+    retry_at  = "45.0"
+    expect(Poison, :encode!, [job], :payload)
+    expect(Redix, :command, [:redis, ["ZADD", "retry", retry_at, :payload]], { :ok, 1 })
+
+    add(job, failed_at, :redis)
+
+    assert validate [Poison, Redix]
+  end
+
   test "count" do
     expect(SortedSet, :count, [key, Verk.Redis], 1)
 


### PR DESCRIPTION
This PR replaces the list for a set to store the dead jobs. It also extracts the retry and dead set code to their modules making QueueManager just a user.