### PR TITLE
Change QueueManager dequeue to limit to 100 jobs

### DIFF
--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -74,7 +74,7 @@ defmodule Verk.WorkersManager do
     if free_workers != 0 do
       case Verk.QueueManager.dequeue(state.queue_manager_name, free_workers) do
         jobs when is_list(jobs) ->
-          for job <- jobs, do: start_job(job, state)
+          for job <- jobs, do: Verk.Job.decode!(job) |> start_job(state)
         reason ->
           Logger.error("Failed to fetch a job. Reason: #{inspect reason}")
       end

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -117,7 +117,8 @@ defmodule Verk.WorkersManagerTest do
                     pool_size: 1, queue_manager_name: queue_manager_name }
     job = %Verk.Job{ class: module, args: args, jid: job_id }
 
-    expect(Verk.QueueManager, :dequeue, [queue_manager_name, 1], [job])
+    expect(Verk.QueueManager, :dequeue, [queue_manager_name, 1], [:encoded_job])
+    expect(Verk.Job, :decode!, [:encoded_job], job)
     expect(:poolboy, :checkout, [pool_name, false], worker)
     expect(Verk.Worker, :perform_async, [worker, worker, module, args, job_id], :ok)
 


### PR DESCRIPTION
This PR changes the way `QueueManager` dequeues jobs. Right now the queue manager will try to fetch as many jobs as the `WorkersManager` wants but this can be dangerous as if it takes more than 5 seconds to receive a response the call will timeout and these jobs will be not processed till `WorkersManager` starts again.

I also moved the decoding to the client side as it's an unnecessary computation happening on the `QueueManager` side that would add for the possible timeout.

Now it will dequeue a max of 100 jobs.