### PR TITLE
Persist queue stats

### DIFF
--- a/lib/verk/queue_stats.ex
+++ b/lib/verk/queue_stats.ex
@@ -14,6 +14,16 @@ defmodule Verk.QueueStats do
 
   @persist_interval 10_000
 
+  @doc """
+  Lists the queues and their stats
+  """
+  @spec all :: Map.t
+  def all do
+    for { queue, running, finished, failed } <- QueueStatsCounters.all, is_binary(queue) do
+      %{ queue: queue, running_counter: running, finished_counter: finished, failed_counter: failed }
+    end
+  end
+
   @doc false
   def init(_) do
     QueueStatsCounters.init

--- a/lib/verk/queue_stats_counters.ex
+++ b/lib/verk/queue_stats_counters.ex
@@ -1,0 +1,71 @@
+defmodule Verk.QueueStatsCounters do
+  @moduledoc """
+  This module is responsible for abstracting the logic of keeping counters for
+  each queue.
+  """
+
+  @counters :queue_stats
+  @ets_options [:ordered_set, :named_table, read_concurrency: true, keypos: 1]
+
+  @doc """
+  Initializes the ets tables for the queue stats.
+  """
+  @spec init :: :ok
+  def init do
+    :ets.new(@counters, @ets_options)
+    :ok
+  end
+
+  @doc """
+  Updates the counters according to the event that happened.
+  """
+  @spec register(:started | :finished | :failed, binary) :: integer
+  def register(:started, queue), do: update_counters(queue, { 2, 1 })
+  def register(:finished, queue), do: update_counters(queue, [{ 3, 1 }, { 2, -1 }])
+  def register(:failed, queue), do: update_counters(queue, [{ 4, 1 }, { 2, -1 }])
+
+  @doc """
+  Saves processed and failed total counts to Redis.
+  """
+  @spec persist :: {:ok, [Redix.Protocol.redis_value]} | {:error, atom}
+  def persist do
+    {total_processed, total_failed} = Enum.reduce stats, {0, 0}, fn {queue, processed, failed}, {accum_processed, accum_failed} ->
+      redis_commands = [
+        incrby(queue, :processed, processed),
+        incrby(queue, :failed, failed)
+      ]
+      case Redix.pipeline(Verk.Redis, redis_commands) do
+        {:ok, [%Redix.Error{}, %Redix.Error{}]} ->
+          {accum_processed, accum_failed}
+        {:ok, [_, %Redix.Error{}]} ->
+          update_counters(queue, { 3, -processed })
+          {accum_processed + processed, accum_failed}
+        {:ok, [%Redix.Error{}, _]} ->
+          update_counters(queue, { 4, -failed })
+          {accum_processed, accum_failed + failed}
+        {:ok, [_, _]} ->
+          update_counters(queue, [{ 3, -processed }, { 4, -failed }])
+          {accum_processed + processed, accum_failed + failed}
+        _error ->
+          {accum_processed, accum_failed}
+      end
+    end
+
+    redis_commands = [
+      incrby(:total, :processed, total_processed),
+      incrby(:total, :failed, total_failed)
+    ]
+    Redix.pipeline(Verk.Redis, redis_commands)
+  end
+
+  defp update_counters(queue, operations) do
+    :ets.update_counter(@counters, queue, operations, { queue, 0, 0, 0 })
+  end
+
+  defp stats do
+    :ets.select(@counters, [{{:"$1", :_, :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
+  end
+
+  defp incrby(:total, attribute, increment), do: ["INCRBY", "stat:#{attribute}", increment]
+  defp incrby(queue, attribute, increment), do: ["INCRBY", "stat:#{attribute}:#{queue}", increment]
+end

--- a/lib/verk/stats.ex
+++ b/lib/verk/stats.ex
@@ -1,0 +1,17 @@
+defmodule Verk.Stats do
+  @moduledoc """
+  Basic stats for Verk
+  """
+
+  @doc """
+  Total amount of processed and failed jobs
+  """
+  @spec total(GenServer.server) :: Map.t
+  def total(redis \\ Verk.Redis) do
+    [processed, failed] = Redix.command!(redis, ~w(MGET stat:processed stat:failed))
+    %{ processed: to_int(processed), failed: to_int(failed) }
+  end
+
+  defp to_int(nil), do: 0
+  defp to_int(string), do: String.to_integer(string)
+end

--- a/test/queue_stats_test.exs
+++ b/test/queue_stats_test.exs
@@ -8,6 +8,11 @@ defmodule Verk.QueueStatsTest do
     { :ok, _ } = Application.fetch_env(:verk, :redis_url)
                   |> elem(1)
                   |> Redix.start_link([name: Verk.Redis])
+    Redix.pipeline!(Verk.Redis, [["DEL",
+        "stat:failed", "stat:processed",
+        "stat:failed:queue_1", "stat:processed:queue_1",
+        "stat:failed:queue_2", "stat:processed:queue_2"
+      ]])
     :ok
   end
 
@@ -25,7 +30,7 @@ defmodule Verk.QueueStatsTest do
 
     assert handle_event(event, :state) == { :ok, :state }
 
-    assert :ets.tab2list(@table) == [{"queue", 1, 0, 0}]
+    assert :ets.tab2list(@table) == [{ :total, 1, 0, 0, 0, 0 }, { "queue", 1, 0, 0, 0, 0 }]
   end
 
   test "handle_event with finished event" do
@@ -34,7 +39,7 @@ defmodule Verk.QueueStatsTest do
 
     assert handle_event(event, :state) == { :ok, :state }
 
-    assert :ets.tab2list(@table) == [{"queue", -1, 1, 0}]
+    assert :ets.tab2list(@table) == [{ :total, -1, 1, 0, 0, 0 }, { "queue", -1, 1, 0, 0, 0 }]
   end
 
   test "handle_event with failed event" do
@@ -43,40 +48,48 @@ defmodule Verk.QueueStatsTest do
 
     assert handle_event(event, :state) == { :ok, :state }
 
-    assert :ets.tab2list(@table) == [{"queue", -1, 0, 1}]
+    assert :ets.tab2list(@table) == [{ :total, -1, 0, 1, 0, 0 }, { "queue", -1, 0, 1, 0, 0 }]
   end
 
   test "persist processed and failed counts" do
     init([])
-    Redix.pipeline!(Verk.Redis, [["DEL",
-      "stat:failed", "stat:processed",
-      "stat:failed:queue_1", "stat:processed:queue_1",
-      "stat:failed:queue_2", "stat:processed:queue_2"
-    ]])
-    handle_event(%Verk.Events.JobFinished{ job: %Verk.Job{ queue: "queue_1" } }, :state)
-    handle_event(%Verk.Events.JobFailed{ job: %Verk.Job{ queue: "queue_2" } }, :state)
-    handle_info(:persist_stats, :state)
-    result = Redix.pipeline!(Verk.Redis, [
-      ["GET", "stat:processed:queue_1"], ["GET", "stat:failed:queue_1"],
-      ["GET", "stat:processed:queue_2"], ["GET", "stat:failed:queue_2"],
-      ["GET", "stat:processed"], ["GET", "stat:failed"]
-    ])
+
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobFailed{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_2" } }, :state)
+    handle_event(%Verk.Events.JobFinished{ job: %Verk.Job{ queue: "queue_2" } }, :state)
+
+    assert handle_info(:persist_stats, :state) == {:ok, :state}
+
+    result = Redix.command!(Verk.Redis, ["MGET", "stat:processed:queue_1", "stat:failed:queue_1",
+                                                 "stat:processed:queue_2", "stat:failed:queue_2",
+                                                 "stat:processed", "stat:failed"])
     assert result == [
-      "1", "0",
-      "0", "1",
+      nil, "1",
+      "1", nil,
       "1", "1"
     ]
 
-    handle_event(%Verk.Events.JobFinished{ job: %Verk.Job{ queue: "queue_2" } }, :state)
-    handle_info(:persist_stats, :state)
-    result = Redix.pipeline!(Verk.Redis, [
-      ["GET", "stat:processed:queue_1"], ["GET", "stat:failed:queue_1"],
-      ["GET", "stat:processed:queue_2"], ["GET", "stat:failed:queue_2"],
-      ["GET", "stat:processed"], ["GET", "stat:failed"]
-    ])
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobFinished{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    assert handle_info(:persist_stats, :state) == { :ok, :state }
+    result = Redix.command!(Verk.Redis, ["MGET", "stat:processed:queue_1", "stat:failed:queue_1",
+                                                 "stat:processed:queue_2", "stat:failed:queue_2",
+                                                 "stat:processed", "stat:failed"])
     assert result == [
-      "1", "0",
       "1", "1",
+      "1", nil,
+      "2", "1"
+    ]
+
+    assert handle_info(:persist_stats, :state) == { :ok, :state }
+
+    result = Redix.command!(Verk.Redis, ["MGET", "stat:processed:queue_1", "stat:failed:queue_1",
+                                                 "stat:processed:queue_2", "stat:failed:queue_2",
+                                                 "stat:processed", "stat:failed"])
+    assert result == [
+      "1", "1",
+      "1", nil,
       "2", "1"
     ]
   end

--- a/test/queue_stats_test.exs
+++ b/test/queue_stats_test.exs
@@ -16,6 +16,19 @@ defmodule Verk.QueueStatsTest do
     :ok
   end
 
+  test "all" do
+    init([]) # create table
+
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_2" } }, :state)
+    handle_event(%Verk.Events.JobFinished{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobFailed{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+
+    assert all == [%{ queue: "queue_1", running_counter: 0, finished_counter: 1, failed_counter: 1 },
+                   %{ queue: "queue_2", running_counter: 1, finished_counter: 0, failed_counter: 0 } ]
+  end
+
   test "init creates an ETS table" do
     assert :ets.info(@table) == :undefined
 

--- a/test/queue_stats_test.exs
+++ b/test/queue_stats_test.exs
@@ -4,6 +4,13 @@ defmodule Verk.QueueStatsTest do
 
   @table :queue_stats
 
+  setup do
+    { :ok, _ } = Application.fetch_env(:verk, :redis_url)
+                  |> elem(1)
+                  |> Redix.start_link([name: Verk.Redis])
+    :ok
+  end
+
   test "init creates an ETS table" do
     assert :ets.info(@table) == :undefined
 
@@ -39,23 +46,38 @@ defmodule Verk.QueueStatsTest do
     assert :ets.tab2list(@table) == [{"queue", -1, 0, 1}]
   end
 
-  test "all with no data" do
-    init([]) # create table
-
-    assert all == []
-  end
-
-  test "all with different events happening" do
-    init([]) # create table
-
-    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
-    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
-    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_1" } }, :state)
-    handle_event(%Verk.Events.JobStarted{ job: %Verk.Job{ queue: "queue_2" } }, :state)
+  test "persist processed and failed counts" do
+    init([])
+    Redix.pipeline!(Verk.Redis, [["DEL",
+      "stat:failed", "stat:processed",
+      "stat:failed:queue_1", "stat:processed:queue_1",
+      "stat:failed:queue_2", "stat:processed:queue_2"
+    ]])
     handle_event(%Verk.Events.JobFinished{ job: %Verk.Job{ queue: "queue_1" } }, :state)
-    handle_event(%Verk.Events.JobFailed{ job: %Verk.Job{ queue: "queue_1" } }, :state)
+    handle_event(%Verk.Events.JobFailed{ job: %Verk.Job{ queue: "queue_2" } }, :state)
+    handle_info(:persist_stats, :state)
+    result = Redix.pipeline!(Verk.Redis, [
+      ["GET", "stat:processed:queue_1"], ["GET", "stat:failed:queue_1"],
+      ["GET", "stat:processed:queue_2"], ["GET", "stat:failed:queue_2"],
+      ["GET", "stat:processed"], ["GET", "stat:failed"]
+    ])
+    assert result == [
+      "1", "0",
+      "0", "1",
+      "1", "1"
+    ]
 
-    assert all == [%{ queue: "queue_1", running_counter: 1, finished_counter: 1, failed_counter: 1 },
-                   %{ queue: "queue_2", running_counter: 1, finished_counter: 0, failed_counter: 0 } ]
+    handle_event(%Verk.Events.JobFinished{ job: %Verk.Job{ queue: "queue_2" } }, :state)
+    handle_info(:persist_stats, :state)
+    result = Redix.pipeline!(Verk.Redis, [
+      ["GET", "stat:processed:queue_1"], ["GET", "stat:failed:queue_1"],
+      ["GET", "stat:processed:queue_2"], ["GET", "stat:failed:queue_2"],
+      ["GET", "stat:processed"], ["GET", "stat:failed"]
+    ])
+    assert result == [
+      "1", "0",
+      "1", "1",
+      "2", "1"
+    ]
   end
 end

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -1,0 +1,22 @@
+defmodule Verk.StatsTest do
+  use ExUnit.Case
+  import Verk.Stats
+
+  setup do
+    { :ok, redis } = Application.fetch_env(:verk, :redis_url)
+                       |> elem(1)
+                       |> Redix.start_link
+    Redix.command!(redis, ~w(DEL stat:processed stat:failed))
+    { :ok, redis: redis }
+  end
+
+  test "total with no data", %{ redis: redis } do
+    assert total(redis) == %{ processed: 0, failed: 0 }
+  end
+
+  test "total with data", %{ redis: redis } do
+    Redix.command!(redis, ~w(MSET stat:processed 25 stat:failed 32))
+
+    assert total(redis) == %{ processed: 25, failed: 32 }
+  end
+end


### PR DESCRIPTION
This PR is based on initial implementation provided by @iurifq (https://github.com/edgurgel/verk/pull/36)

It keeps the old API and persists the data to Redis each 10 seconds (is this a good default?)