### PR TITLE
Fix WorkersManager.inspect_worker when process is gone

### DIFF
--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -46,7 +46,7 @@ defmodule Verk.WorkersManager do
     end
   end
 
-  @process_info [:current_stacktrace, :initial_call, :reductions, :status]
+  @process_info_keys [:current_stacktrace, :initial_call, :reductions, :status]
   @doc """
   List information about the process that is currently running a `job_id`
   """
@@ -55,7 +55,12 @@ defmodule Verk.WorkersManager do
     case :ets.match(name(queue), { :'$1', job_id, :'$2', :_, :'$3' }) do
       [] -> { :error, :not_found }
       [[pid, job, started_at]] ->
-        { :ok, %{ process: pid, job: job, started_at: started_at, info: Process.info(pid, @process_info) } }
+        info = Process.info(pid, @process_info_keys)
+        if info do
+          { :ok, %{ process: pid, job: job, started_at: started_at, info: info } }
+        else
+          { :error, :not_found }
+        end
     end
   end
 

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -73,6 +73,14 @@ defmodule Verk.WorkersManagerTest do
     assert Enum.all?(expected, &Keyword.has_key?(result[:info], &1))
   end
 
+  test "inspect_worker with matching job_id but process is gone", %{ monitors: monitors } do
+    pid = :erlang.list_to_pid('<3.57.1>')
+    row = { pid, "job_id", "job data", make_ref, "start_time" }
+    :ets.insert(monitors, row)
+
+    assert inspect_worker("queue_name", "job_id") == { :error, :not_found }
+  end
+
   test "init" do
     name = :workers_manager
     queue_name = "queue_name"


### PR DESCRIPTION
The process may be gone when we are asking for its process info