### PR TITLE
Refactor workers manager

### DIFF
--- a/lib/verk/worker.ex
+++ b/lib/verk/worker.ex
@@ -26,9 +26,10 @@ defmodule Verk.Worker do
     try do
       apply(String.to_atom("Elixir.#{module}"), :perform, args)
       GenServer.cast(manager, { :done, self, job_id })
+      { :stop, :normal, state }
     rescue
       exception -> GenServer.cast(manager, { :failed, self, job_id, exception, System.stacktrace })
+      { :stop, :failed, state }
     end
-    { :stop, :normal, state }
   end
 end

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -25,7 +25,7 @@ defmodule Verk.WorkerTest do
   test "cast perform runs the specified module with the args failing" do
     worker = self
     exception = ArgumentError.exception("invalid argument arg1")
-    assert handle_cast({ :perform, "FailWorker", ["arg1"], "job_id", worker }, :state) == { :stop, :normal, :state }
+    assert handle_cast({ :perform, "FailWorker", ["arg1"], "job_id", worker }, :state) == { :stop, :failed, :state }
 
     assert_receive { :"$gen_cast", { :failed, ^worker, "job_id", ^exception, _ } }
   end

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -22,6 +22,7 @@ defmodule Verk.WorkersManagerTest do
 
   setup do
     pid = self
+    new :poolboy
     on_exit fn ->
       GenEvent.remove_handler(Verk.EventManager, TestHandler, pid)
       unload
@@ -155,7 +156,6 @@ defmodule Verk.WorkersManagerTest do
     job = %Verk.Job{}
     job_id = "job_id"
 
-    expect(:poolboy, :checkin, [pool_name, worker], :ok)
     expect(Verk.QueueManager, :ack, [queue_manager_name, job], :ok)
 
     :ets.insert(monitors, { worker, job_id, job, make_ref, Timex.Date.now })
@@ -180,7 +180,6 @@ defmodule Verk.WorkersManagerTest do
 
     state = %State{ monitors: monitors, pool_name: pool_name, queue_manager_name: queue_manager_name }
 
-    expect(:poolboy, :checkin, [pool_name, worker], true)
     expect(Verk.Log, :fail, [job, "start_time", worker], :ok)
     expect(Verk.QueueManager, :retry, [queue_manager_name, job, exception, :stacktrace], :ok)
     expect(Verk.QueueManager, :ack, [queue_manager_name, job], :ok)
@@ -208,7 +207,6 @@ defmodule Verk.WorkersManagerTest do
 
     state = %State{ monitors: monitors, pool_name: pool_name, queue_manager_name: queue_manager_name }
 
-    expect(:poolboy, :checkin, [pool_name, worker], true)
     expect(Verk.Log, :fail, [job, "start_time", worker], :ok)
     expect(Verk.QueueManager, :retry, [queue_manager_name, job, exception, []], :ok)
     expect(Verk.QueueManager, :ack, [queue_manager_name, job], :ok)
@@ -223,8 +221,51 @@ defmodule Verk.WorkersManagerTest do
     assert validate [:poolboy, Verk.Log, Verk.QueueManager]
   end
 
-  test "handle info DOWN coming from dead worker with normal reason" do
-    assert handle_info({ :DOWN, :_, :_, :_, :normal }, :state) == { :noreply, :state, 0 }
+  test "handle info DOWN coming from dead worker with normal reason", %{ monitors: monitors } do
+    queue_manager_name = "queue_manager_name"
+    pool_name = "pool_name"
+    state = %State{ monitors: monitors, pool_name: pool_name, queue_manager_name: queue_manager_name }
+    worker = self
+    job = %Verk.Job{}
+    job_id = "job_id"
+    ref = make_ref
+
+    expect(Verk.QueueManager, :ack, [queue_manager_name, job], :ok)
+
+    :ets.insert(monitors, { worker, job_id, job, ref, Timex.Date.now })
+    assert handle_info({ :DOWN, ref, :_, worker, :normal }, state) == { :noreply, state, 0 }
+
+    assert :ets.lookup(state.monitors, worker) == []
+    assert_receive %Verk.Events.JobFinished{ job: ^job, finished_at: _ }
+
+    assert validate Verk.QueueManager
+  end
+
+  test "handle info DOWN coming from dead worker with failed reason", %{ monitors: monitors } do
+    ref = make_ref
+    worker = self
+    pool_name = "pool_name"
+    job = "job"
+    job_id = "job_id"
+    queue_manager_name = "queue_manager_name"
+    exception = RuntimeError.exception(":failed")
+
+    :ets.insert(monitors, { worker, job_id, job, ref, "start_time" })
+
+    state = %State{ monitors: monitors, pool_name: pool_name, queue_manager_name: queue_manager_name }
+
+    expect(Verk.Log, :fail, [job, "start_time", worker], :ok)
+    expect(Verk.QueueManager, :retry, [queue_manager_name, job, exception, []], :ok)
+    expect(Verk.QueueManager, :ack, [queue_manager_name, job], :ok)
+
+    assert handle_info({ :DOWN, ref, :_, worker, :failed }, state) == { :noreply, state, 0 }
+
+    assert :ets.lookup(monitors, worker) == []
+    assert_receive %Verk.Events.JobFailed{ job: ^job, failed_at: _,
+                                           stacktrace: [],
+                                           exception: ^exception }
+
+    assert validate [Verk.Log, Verk.QueueManager]
   end
 
   test "cast failed coming from worker", %{ monitors: monitors } do
@@ -240,7 +281,6 @@ defmodule Verk.WorkersManagerTest do
 
     state = %State{ monitors: monitors, pool_name: pool_name, queue_manager_name: queue_manager_name }
 
-    expect(:poolboy, :checkin, [pool_name, worker], true)
     expect(Verk.Log, :fail, [job, "start_time", worker], :ok)
     expect(Verk.QueueManager, :retry, [queue_manager_name, job, exception, :stacktrace], :ok)
     expect(Verk.QueueManager, :ack, [queue_manager_name, job], :ok)
@@ -252,6 +292,6 @@ defmodule Verk.WorkersManagerTest do
                                            stacktrace: :stacktrace,
                                            exception: ^exception }
 
-    assert validate [:poolboy, Verk.Log, Verk.QueueManager]
+    assert validate [Verk.Log, Verk.QueueManager]
   end
 end


### PR DESCRIPTION
It will always react to DOWN messages so there's no way a worker will be "lost"