### PR TITLE
Update usage of Timex to comply with Timex 2.x requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Verk.enqueue(%Verk.Job{queue: :default, class: "ExampleWorker", args: [1,2]})
 This job can also be scheduled using `Verk.schedule/2`:
 
  ```elixir
- perform_at = Timex.Date.shift(Timex.Date.now, secs: 30)
+ perform_at = Timex.shift(Timex.DateTime.now, seconds: 30)
  Verk.schedule(%Verk.Job{queue: :default, class: "ExampleWorker", args: [1,2]}, perform_at)
  ```
 

--- a/lib/verk.ex
+++ b/lib/verk.ex
@@ -12,7 +12,6 @@ defmodule Verk do
   alias Verk.Job
   alias Timex.Time
   alias Timex.DateTime
-  alias Timex.Date
 
   @schedule_key "schedule"
 
@@ -79,7 +78,7 @@ defmodule Verk do
     schedule(%Job{ job | jid: generate_jid }, perform_at, redis)
   end
   def schedule(%Job{ jid: jid } = job, %DateTime{} = perform_at, redis) do
-    perform_at_secs = Date.to_secs(perform_at)
+    perform_at_secs = DateTime.to_secs(perform_at)
 
     if perform_at_secs < Time.now(:seconds) do
       enqueue(job, redis)

--- a/lib/verk/log.ex
+++ b/lib/verk/log.ex
@@ -2,7 +2,7 @@ defmodule Verk.Log do
   require Logger
   import Logger
   alias Verk.Job
-  alias Timex.Date
+  alias Timex.DateTime
 
   def start(%Job{jid: job_id, class: module}, process_id) do
     info("#{module} #{job_id} start", process_id: inspect(process_id))
@@ -17,6 +17,6 @@ defmodule Verk.Log do
   end
 
   defp elapsed(start_time) do
-    start_time |> Date.diff(Date.now, :seconds)
+    start_time |> Timex.diff(DateTime.now, :seconds)
   end
 end

--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -165,7 +165,7 @@ defmodule Verk.WorkersManager do
     Verk.QueueManager.ack(queue_manager_name, job)
     Verk.Log.done(job, start_time, worker)
     demonitor!(monitors, worker, mref)
-    notify!(%Events.JobFinished{ job: job, finished_at: Timex.Date.now })
+    notify!(%Events.JobFinished{ job: job, finished_at: Timex.DateTime.now })
   end
 
   defp fail(job, start_time, worker, mref, monitors, queue_manager_name, exception, stacktrace) do
@@ -173,7 +173,7 @@ defmodule Verk.WorkersManager do
     demonitor!(monitors, worker, mref)
     :ok = Verk.QueueManager.retry(queue_manager_name, job, exception, stacktrace)
     :ok = Verk.QueueManager.ack(queue_manager_name, job)
-    notify!(%Events.JobFailed{ job: job, failed_at: Timex.Date.now, exception: exception, stacktrace: stacktrace })
+    notify!(%Events.JobFailed{ job: job, failed_at: Timex.DateTime.now, exception: exception, stacktrace: stacktrace })
   end
 
   defp start_job(job = %Verk.Job{ jid: job_id, class: module, args: args }, state) do
@@ -182,7 +182,7 @@ defmodule Verk.WorkersManager do
         monitor!(state.monitors, worker, job)
         Verk.Log.start(job, worker)
         ask_to_perform(worker, job_id, module, args)
-        notify!(%Events.JobStarted{ job: job, started_at: Timex.Date.now })
+        notify!(%Events.JobStarted{ job: job, started_at: Timex.DateTime.now })
     end
   end
 
@@ -193,7 +193,7 @@ defmodule Verk.WorkersManager do
 
   defp monitor!(monitors, worker, job = %Verk.Job{ jid: job_id }) do
     mref = Process.monitor(worker)
-    now = Timex.Date.now
+    now = Timex.DateTime.now
     true = :ets.insert(monitors, { worker, job_id, job, mref, now })
   end
 

--- a/test/verk_test.exs
+++ b/test/verk_test.exs
@@ -120,7 +120,7 @@ defmodule VerkTest do
     job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker", args: [] }
     encoded_job = "encoded_job"
     expect(Poison, :encode!, [job], encoded_job)
-    perform_at_secs = Timex.Date.to_secs(perform_at)
+    perform_at_secs = Timex.DateTime.to_seconds(perform_at)
     expect(Redix, :command, [Verk.Redis, ["ZADD", "schedule", perform_at_secs, encoded_job]], { :ok, :_ })
 
     assert schedule(job, perform_at) == { :ok, "job_id" }
@@ -134,7 +134,7 @@ defmodule VerkTest do
     job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker", args: [] }
     encoded_job = "encoded_job"
     expect(Poison, :encode!, [job], encoded_job)
-    perform_at_secs = Timex.Date.to_secs(perform_at)
+    perform_at_secs = Timex.DateTime.to_seconds(perform_at)
     expect(Redix, :command, [:my_redis, ["ZADD", "schedule", perform_at_secs, encoded_job]], { :ok, :_ })
 
     assert schedule(job, perform_at, :my_redis) == { :ok, "job_id" }

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -166,7 +166,7 @@ defmodule Verk.WorkersManagerTest do
 
     expect(Verk.QueueManager, :ack, [queue_manager_name, job], :ok)
 
-    :ets.insert(monitors, { worker, job_id, job, make_ref, Timex.Date.now })
+    :ets.insert(monitors, { worker, job_id, job, make_ref, Timex.DateTime.now })
     assert handle_cast({ :done, worker, job_id }, state) == { :noreply, state, 0 }
 
     assert :ets.lookup(state.monitors, worker) == []
@@ -240,7 +240,7 @@ defmodule Verk.WorkersManagerTest do
 
     expect(Verk.QueueManager, :ack, [queue_manager_name, job], :ok)
 
-    :ets.insert(monitors, { worker, job_id, job, ref, Timex.Date.now })
+    :ets.insert(monitors, { worker, job_id, job, ref, Timex.DateTime.now })
     assert handle_info({ :DOWN, ref, :_, worker, :normal }, state) == { :noreply, state, 0 }
 
     assert :ets.lookup(state.monitors, worker) == []


### PR DESCRIPTION
In #43 I've missed to update the code where Timex is used to match version 2.x as explained in [Timex Migration steps](https://github.com/bitwalker/timex#migration-steps-1x---2x).

Some of it is just nice to have, but other might be breaking things, like for example `Date.now` is returning date instead of datetime:
```
iex(2)> Timex.Date.now
#<Date(2016-04-05)>
iex(3)> Timex.DateTime.now
#<DateTime(2016-04-05T10:59:29Z)>
```