### PR TITLE
also allow poison 2.0 as dep

### DIFF
--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -1,4 +1,5 @@
 defmodule Verk.Job do
+  use Verk.PoisonVersion
   @keys [error_message: nil, failed_at: nil, retry_count: 0, queue: nil, class: nil, args: [],
          jid: nil, finished_at: nil, enqueued_at: nil, retried_at: nil, error_backtrace: nil]
 
@@ -10,7 +11,10 @@ defmodule Verk.Job do
   """
   @spec decode!(binary) :: %__MODULE__{}
   def decode!(payload) do
-    job = Poison.decode!(payload, as: __MODULE__)
+    job = decode!(payload, is_before_poison_2)
     %Verk.Job{ job | original_json: payload }
   end
+
+  def decode!(payload, true),  do: Poison.decode!(payload, as: __MODULE__)
+  def decode!(payload, false), do: Poison.decode!(payload, as: %__MODULE__{})
 end

--- a/lib/verk/poison_version.ex
+++ b/lib/verk/poison_version.ex
@@ -1,0 +1,22 @@
+defmodule Verk.PoisonVersion do
+  defmacro __using__(_) do
+    quote do
+      def poison_version do
+        unquote(Verk.PoisonVersion.runtime_poison_version)
+      end
+
+      def is_before_poison_2 do
+        unquote(Verk.PoisonVersion.runtime_poison_version) |> Version.match?("<2.0.0")
+      end
+    end
+  end
+
+  def runtime_poison_version do
+    Mix.Project.config
+    |> Keyword.get(:deps)
+    |> Mix.Dep.loaded
+    |> Enum.find(fn(%{app: app})-> app == :poison end)
+    |> Map.get(:status)
+    |> elem(1)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Verk.Mixfile do
 
   defp deps do
     [{ :redix, "~> 0.3" },
-     { :poison, "~> 1.5" },
+     { :poison, "~> 1.5 or ~> 2.0"},
      { :timex, "~> 2.0" },
      { :poolboy, "~> 1.5.1" },
      { :watcher, "~> 1.0" },


### PR DESCRIPTION
problem: 
- some projects already use poison 2.0 (or 2.1), verk installation does not work there


solution: 
- also allow poison 2.0 by relaxing dependency

```
{ :poison, "~> 1.5 or ~> 2.0"},
```