### PR TITLE
Reset started counter

### DIFF
--- a/lib/verk/queue_stats.ex
+++ b/lib/verk/queue_stats.ex
@@ -24,6 +24,14 @@ defmodule Verk.QueueStats do
     end
   end
 
+  @doc """
+  Requests to reset started counter for a `queue`
+  """
+  @spec reset_started(binary) :: :ok
+  def reset_started(queue) do
+    GenEvent.call(Verk.EventManager, Verk.QueueStats, { :reset_started, to_string(queue) })
+  end
+
   @doc false
   def init(_) do
     QueueStatsCounters.init
@@ -45,6 +53,12 @@ defmodule Verk.QueueStats do
   def handle_event(%Verk.Events.JobFailed{ job: job }, state) do
     QueueStatsCounters.register(:failed, job.queue)
     { :ok, state }
+  end
+
+  @doc false
+  def handle_call({ :reset_started, queue }, state) do
+    QueueStatsCounters.reset_started(queue)
+    { :ok, :ok, state }
   end
 
   @doc false

--- a/lib/verk/queue_stats_counters.ex
+++ b/lib/verk/queue_stats_counters.ex
@@ -25,6 +25,16 @@ defmodule Verk.QueueStatsCounters do
   end
 
   @doc """
+  It Resets the started counter of a `queue`
+  """
+  @spec reset_started(binary) :: :ok
+  def reset_started(queue) do
+    unless :ets.update_element(@counters_table, queue, { 2, 0 }) do
+      true = :ets.insert_new(@counters_table, new_element(queue))
+    end
+  end
+
+  @doc """
   Updates the counters according to the event that happened.
   """
   @spec register(:started | :finished | :failed, binary) :: integer
@@ -72,8 +82,10 @@ defmodule Verk.QueueStatsCounters do
 
   # started, finished, failed, last_started, last_failed
   defp update_counters(queue, operations) do
-    :ets.update_counter(@counters_table, queue, operations, { queue, 0, 0, 0, 0, 0 })
+    :ets.update_counter(@counters_table, queue, operations, new_element(queue))
   end
+
+  defp new_element(queue), do: { queue, 0, 0, 0, 0, 0 }
 
   defp incrby(_, _, 0), do: nil
   defp incrby(:total, attribute, increment) do

--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -75,9 +75,11 @@ defmodule Verk.WorkersManager do
                     pool_size: size,
                     monitors: monitors }
 
-    send self, :enqueue_inprogress
-
     Logger.info "Workers Manager started for queue #{queue_name}"
+
+    send self, :enqueue_inprogress
+    Verk.QueueStats.reset_started(queue_name)
+
     { :ok, state }
   end
 

--- a/test/queue_stats_test.exs
+++ b/test/queue_stats_test.exs
@@ -29,6 +29,21 @@ defmodule Verk.QueueStatsTest do
                    %{ queue: "queue_2", running_counter: 1, finished_counter: 0, failed_counter: 0 } ]
   end
 
+  test "handle_call reset_started with no element" do
+    init([]) # create table
+
+    assert handle_call({ :reset_started, "queue" }, :state) == { :ok, :ok, :state }
+    assert :ets.tab2list(@table) == [{ "queue", 0, 0, 0, 0, 0 }]
+  end
+
+  test "handle_call reset_started with existing element" do
+    init([]) # create table
+    :ets.insert_new(@table, { "queue", 1, 2, 3, 4, 5 })
+
+    assert handle_call({ :reset_started, "queue" }, :state) == { :ok, :ok, :state }
+    assert :ets.tab2list(@table) == [{ "queue", 0, 2, 3, 4, 5 }]
+  end
+
   test "init creates an ETS table" do
     assert :ets.info(@table) == :undefined
 

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -91,11 +91,13 @@ defmodule Verk.WorkersManagerTest do
     state = %State{ queue_name: queue_name, queue_manager_name: queue_manager_name,
                     pool_name: pool_name, pool_size: pool_size,
                     monitors: :workers_manager }
+    expect(Verk.QueueStats, :reset_started, [queue_name], :ok)
 
     assert init([name, queue_name, queue_manager_name, pool_name, pool_size])
       == { :ok, state }
 
     assert_received :enqueue_inprogress
+    assert validate Verk.QueueStats
   end
 
   test "handle info enqueue_inprogress" do


### PR DESCRIPTION
This is necessary so that if the WorkersManager restarts the started counter to 0 as no worker survived to fail/finish the previous running jobs.

There's also the nice side-effect of always registering the queue to QueueStats even if no job ever runs for this queue. Previously it would register just if at least 1 job ran.