### PR TITLE
show job time down to milliseconds

### DIFF
--- a/lib/verk/log.ex
+++ b/lib/verk/log.ex
@@ -13,14 +13,22 @@ defmodule Verk.Log do
   end
 
   def done(%Job{jid: job_id, class: module}, start_time, process_id) do
-    info("#{module} #{job_id} done: #{elapsed(start_time)} secs", process_id: inspect(process_id))
+    info("#{module} #{job_id} done: #{elapsed_time(start_time)}", process_id: inspect(process_id))
   end
 
   def fail(%Job{jid: job_id, class: module}, start_time, process_id) do
-    info("#{module} #{job_id} fail: #{elapsed(start_time)} secs", process_id: inspect(process_id))
+    info("#{module} #{job_id} fail: #{elapsed_time(start_time)}", process_id: inspect(process_id))
   end
 
-  defp elapsed(start_time) do
-    start_time |> Timex.diff(DateTime.now, :seconds)
+  defp elapsed_time(start_time) do
+    now = DateTime.now
+    seconds_diff = start_time |> Timex.diff(now, :seconds)
+
+    if seconds_diff == 0 do
+      milliseconds_diff = now.millisecond - start_time.millisecond
+      "#{milliseconds_diff} ms"
+    else
+      "#{seconds_diff} s"
+    end
   end
 end

--- a/test/log_test.exs
+++ b/test/log_test.exs
@@ -1,0 +1,46 @@
+defmodule Verk.LogTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+
+  test "logs done with time in milliseconds" do
+    worker = self
+    job = %Verk.Job{}
+    start_time = Timex.DateTime.now
+
+    assert capture_log(fn ->
+      Verk.Log.done(job, start_time, worker)
+    end) =~ ~r/done: \d+ ms/
+  end
+
+  test "logs done with time in seconds" do
+    worker = self
+    job = %Verk.Job{}
+    start_time = Timex.DateTime.now
+    |> Timex.shift(seconds: -2)
+
+    assert capture_log(fn ->
+      Verk.Log.done(job, start_time, worker)
+    end) =~ ~r/done: \d+ s/
+  end
+
+  test "logs fail with time in milliseconds" do
+    worker = self
+    job = %Verk.Job{}
+    start_time = Timex.DateTime.now
+
+    assert capture_log(fn ->
+      Verk.Log.fail(job, start_time, worker)
+    end) =~ ~r/fail: \d+ ms/
+  end
+
+  test "logs fail with time in seconds" do
+    worker = self
+    job = %Verk.Job{}
+    start_time = Timex.DateTime.now
+    |> Timex.shift(seconds: -2)
+
+    assert capture_log(fn ->
+      Verk.Log.fail(job, start_time, worker)
+    end) =~ ~r/fail: \d+ s/
+  end
+end


### PR DESCRIPTION
This as an attempt at closing https://github.com/edgurgel/verk/issues/34, but `Timex.DateTime` only has granularity to milliseconds ([link](https://github.com/bitwalker/timex/blob/master/lib/datetime/datetime.ex#L25-L33)) and `Timex.Diff` doesn't allow you to specify milliseconds ([link](https://github.com/bitwalker/timex/blob/fcacaffa5ca015e807af87b5d211912bce0587d9/lib/comparable/comparable.ex#L15-L25)) so I ended up manually subtracting the DateTime milliseconds from each other if the seconds difference is zero.

For units smaller than milliseconds, I think it would require using `Timex.Time`, which would require more work and potentially break compatibility?

Thank you for making verk :)

