### PR TITLE
Configurable workers manager timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config :verk, queues: [{:default, 25}], poll_interval: 5000, node_id: "1", redis_url: "redis://127.0.0.1:6379"
+config :verk, queues: [{:default, 25}], poll_interval: 5000, node_id: "1", redis_url: "redis://127.0.0.1:6379", workers_manager_timeout: 1200
 config :logger, :console,
   format: "\n$date $time [$level] $metadata$message\n",
   metadata: [:process_id]

--- a/lib/verk/queue_supervisor.ex
+++ b/lib/verk/queue_supervisor.ex
@@ -9,8 +9,6 @@ defmodule Verk.Queue.Supervisor do
   alias Verk.WorkersManager
   alias Verk.QueueManager
 
-  @default_workers_manager_timeout 1000
-
   @doc false
   def start_link(name, size) do
     supervisor_name = String.to_atom("#{name}.supervisor")
@@ -22,12 +20,9 @@ defmodule Verk.Queue.Supervisor do
     pool_name = String.to_atom("#{name}.pool")
     workers_manager = WorkersManager.name(name)
     queue_manager = QueueManager.name(name)
-    workers_manager_timeout = Application.get_env(:verk, :workers_manager_timeout, @default_workers_manager_timeout)
-    workers_manager_args = [workers_manager, name, queue_manager, pool_name, size, workers_manager_timeout]
-
     children = [worker(QueueManager, [queue_manager, name], id: queue_manager),
                 poolboy_spec(pool_name, size),
-                worker(WorkersManager, workers_manager_args, id: workers_manager)]
+                worker(WorkersManager, [workers_manager, name, queue_manager, pool_name, size], id: workers_manager)]
 
     supervise(children, strategy: :one_for_one)
   end

--- a/lib/verk/queue_supervisor.ex
+++ b/lib/verk/queue_supervisor.ex
@@ -9,6 +9,8 @@ defmodule Verk.Queue.Supervisor do
   alias Verk.WorkersManager
   alias Verk.QueueManager
 
+  @default_workers_manager_timeout 1000
+
   @doc false
   def start_link(name, size) do
     supervisor_name = String.to_atom("#{name}.supervisor")
@@ -20,9 +22,11 @@ defmodule Verk.Queue.Supervisor do
     pool_name = String.to_atom("#{name}.pool")
     workers_manager = WorkersManager.name(name)
     queue_manager = QueueManager.name(name)
+    workers_manager_timeout = Application.get_env(:verk, :workers_manager_timeout, @default_workers_manager_timeout)
+
     children = [worker(QueueManager, [queue_manager, name], id: queue_manager),
                 poolboy_spec(pool_name, size),
-                worker(WorkersManager, [workers_manager, name, queue_manager, pool_name, size], id: workers_manager)]
+                worker(WorkersManager, [workers_manager, name, queue_manager, pool_name, size, workers_manager_timeout], id: workers_manager)]
 
     supervise(children, strategy: :one_for_one)
   end

--- a/lib/verk/queue_supervisor.ex
+++ b/lib/verk/queue_supervisor.ex
@@ -23,10 +23,11 @@ defmodule Verk.Queue.Supervisor do
     workers_manager = WorkersManager.name(name)
     queue_manager = QueueManager.name(name)
     workers_manager_timeout = Application.get_env(:verk, :workers_manager_timeout, @default_workers_manager_timeout)
+    workers_manager_args = [workers_manager, name, queue_manager, pool_name, size, workers_manager_timeout]
 
     children = [worker(QueueManager, [queue_manager, name], id: queue_manager),
                 poolboy_spec(pool_name, size),
-                worker(WorkersManager, [workers_manager, name, queue_manager, pool_name, size, workers_manager_timeout], id: workers_manager)]
+                worker(WorkersManager, workers_manager_args, id: workers_manager)]
 
     supervise(children, strategy: :one_for_one)
   end

--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -12,6 +12,8 @@ defmodule Verk.WorkersManager do
   alias Verk.QueueManager
   alias Verk.Log
 
+  @default_timeout 1000
+
   defmodule State do
     @moduledoc false
     defstruct [:queue_name, :pool_name, :queue_manager_name, :pool_size, :monitors, :timeout]
@@ -26,8 +28,8 @@ defmodule Verk.WorkersManager do
   end
 
   @doc false
-  def start_link(workers_manager_name, queue_name, queue_manager_name, pool_name, pool_size, timeout) do
-    gen_server_args = [workers_manager_name, queue_name, queue_manager_name, pool_name, pool_size, timeout]
+  def start_link(workers_manager_name, queue_name, queue_manager_name, pool_name, pool_size) do
+    gen_server_args = [workers_manager_name, queue_name, queue_manager_name, pool_name, pool_size]
     GenServer.start_link(__MODULE__, gen_server_args, name: workers_manager_name)
   end
 
@@ -71,8 +73,9 @@ defmodule Verk.WorkersManager do
   @doc """
   Create a table to monitor workers saving data about the assigned queue/pool
   """
-  def init([workers_manager_name, queue_name, queue_manager_name, pool_name, size, timeout]) do
+  def init([workers_manager_name, queue_name, queue_manager_name, pool_name, size]) do
     monitors = :ets.new(workers_manager_name, [:named_table, read_concurrency: true])
+    timeout = Application.get_env(:verk, :workers_manager_timeout, @default_timeout)
     state = %State{queue_name: queue_name,
                   queue_manager_name: queue_manager_name,
                   pool_name: pool_name,

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -88,13 +88,13 @@ defmodule Verk.WorkersManagerTest do
     queue_manager_name = "queue_manager_name"
     pool_name = "pool_name"
     pool_size = "size"
-    timeout = 1000
+    timeout = Application.get_env(:verk, :workers_manager_timeout)
     state = %State{ queue_name: queue_name, queue_manager_name: queue_manager_name,
                     pool_name: pool_name, pool_size: pool_size,
                     monitors: :workers_manager, timeout: timeout }
     expect(Verk.QueueStats, :reset_started, [queue_name], :ok)
 
-    assert init([name, queue_name, queue_manager_name, pool_name, pool_size, timeout])
+    assert init([name, queue_name, queue_manager_name, pool_name, pool_size])
       == { :ok, state }
 
     assert_received :enqueue_inprogress

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -88,12 +88,13 @@ defmodule Verk.WorkersManagerTest do
     queue_manager_name = "queue_manager_name"
     pool_name = "pool_name"
     pool_size = "size"
+    timeout = 1000
     state = %State{ queue_name: queue_name, queue_manager_name: queue_manager_name,
                     pool_name: pool_name, pool_size: pool_size,
-                    monitors: :workers_manager }
+                    monitors: :workers_manager, timeout: timeout }
     expect(Verk.QueueStats, :reset_started, [queue_name], :ok)
 
-    assert init([name, queue_name, queue_manager_name, pool_name, pool_size])
+    assert init([name, queue_name, queue_manager_name, pool_name, pool_size, timeout])
       == { :ok, state }
 
     assert_received :enqueue_inprogress
@@ -125,12 +126,13 @@ defmodule Verk.WorkersManagerTest do
 
   test "handle info timeout with free workers and no jobs", %{ monitors: monitors } do
     queue_manager_name = :queue_manager_name
+    timeout = 1000
     state = %State{ monitors: monitors, pool_name: "pool_name",
-                    pool_size: 1, queue_manager_name: queue_manager_name }
+                    pool_size: 1, queue_manager_name: queue_manager_name, timeout: timeout }
 
     expect(Verk.QueueManager, :dequeue, [queue_manager_name, 1], [])
 
-    assert handle_info(:timeout, state) == { :noreply, state, 1000 }
+    assert handle_info(:timeout, state) == { :noreply, state, state.timeout }
 
     assert validate Verk.QueueManager
   end
@@ -138,12 +140,13 @@ defmodule Verk.WorkersManagerTest do
   test "handle info timeout with free workers and jobs to be done", %{ monitors: monitors } do
     queue_manager_name = :queue_manager_name
     pool_name = :pool_name
+    timeout = 1000
     worker = self
     module = :module
     args = [:arg1, :arg2]
     job_id = "job_id"
     state = %State{ monitors: monitors, pool_name: pool_name,
-                    pool_size: 1, queue_manager_name: queue_manager_name }
+                    pool_size: 1, queue_manager_name: queue_manager_name, timeout: timeout }
     job = %Verk.Job{ class: module, args: args, jid: job_id }
 
     expect(Verk.QueueManager, :dequeue, [queue_manager_name, 1], [:encoded_job])
@@ -151,7 +154,7 @@ defmodule Verk.WorkersManagerTest do
     expect(:poolboy, :checkout, [pool_name, false], worker)
     expect(Verk.Worker, :perform_async, [worker, worker, job], :ok)
 
-    assert handle_info(:timeout, state) == { :noreply, state, 1000 }
+    assert handle_info(:timeout, state) == { :noreply, state, state.timeout }
     assert match?([{^worker, ^job_id, ^job, _, _}], :ets.lookup(monitors, worker))
     assert_receive %Verk.Events.JobStarted{ job: ^job, started_at: _ }
 


### PR DESCRIPTION
My initial attempt at closing https://github.com/edgurgel/verk/issues/41

I wasn't sure if the configuration should happen in the WorkersManager module or if it should be passed in from the supervisor as I did.  Credo is also not happy that the number of args is up to 6 for `Verk.WorkersManager.start_link`.