### PR TITLE
random timeout

### DIFF
--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -106,7 +106,7 @@ defmodule Verk.WorkersManager do
         reason ->
           Logger.error("Failed to fetch a job. Reason: #{inspect reason}")
       end
-      {:noreply, state, state.timeout}
+      {:noreply, state, random_timeout(state.timeout)}
     else
       {:noreply, state}
     end
@@ -219,5 +219,9 @@ defmodule Verk.WorkersManager do
 
   defp free_workers(monitors, size) do
     size - :ets.info(monitors, :size)
+  end
+
+  defp random_timeout(timeout) do
+    round(timeout + (:random.uniform * timeout))
   end
 end

--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -222,6 +222,6 @@ defmodule Verk.WorkersManager do
   end
 
   defp random_timeout(timeout) do
-    round(timeout + (:random.uniform * timeout))
+    round(timeout + (:rand.uniform * timeout))
   end
 end

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -125,7 +125,7 @@ defmodule Verk.WorkersManagerTest do
   end
 
   test "handle info timeout with free workers and no jobs", %{ monitors: monitors } do
-    :random.seed(1000)
+    :rand.seed(:exs64, {1,2,3})
     queue_manager_name = :queue_manager_name
     timeout = 1000
     state = %State{ monitors: monitors, pool_name: "pool_name",
@@ -133,13 +133,13 @@ defmodule Verk.WorkersManagerTest do
 
     expect(Verk.QueueManager, :dequeue, [queue_manager_name, 1], [])
 
-    assert handle_info(:timeout, state) == { :noreply, state, 1692 }
+    assert handle_info(:timeout, state) == { :noreply, state, 1350 }
 
     assert validate Verk.QueueManager
   end
 
   test "handle info timeout with free workers and jobs to be done", %{ monitors: monitors } do
-    :random.seed(1000)
+    :rand.seed(:exs64, {1,2,3})
     queue_manager_name = :queue_manager_name
     pool_name = :pool_name
     timeout = 1000
@@ -156,7 +156,7 @@ defmodule Verk.WorkersManagerTest do
     expect(:poolboy, :checkout, [pool_name, false], worker)
     expect(Verk.Worker, :perform_async, [worker, worker, job], :ok)
 
-    assert handle_info(:timeout, state) == { :noreply, state, 1692 }
+    assert handle_info(:timeout, state) == { :noreply, state, 1350 }
     assert match?([{^worker, ^job_id, ^job, _, _}], :ets.lookup(monitors, worker))
     assert_receive %Verk.Events.JobStarted{ job: ^job, started_at: _ }
 

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -125,6 +125,7 @@ defmodule Verk.WorkersManagerTest do
   end
 
   test "handle info timeout with free workers and no jobs", %{ monitors: monitors } do
+    :random.seed(1000)
     queue_manager_name = :queue_manager_name
     timeout = 1000
     state = %State{ monitors: monitors, pool_name: "pool_name",
@@ -132,12 +133,13 @@ defmodule Verk.WorkersManagerTest do
 
     expect(Verk.QueueManager, :dequeue, [queue_manager_name, 1], [])
 
-    assert handle_info(:timeout, state) == { :noreply, state, state.timeout }
+    assert handle_info(:timeout, state) == { :noreply, state, 1692 }
 
     assert validate Verk.QueueManager
   end
 
   test "handle info timeout with free workers and jobs to be done", %{ monitors: monitors } do
+    :random.seed(1000)
     queue_manager_name = :queue_manager_name
     pool_name = :pool_name
     timeout = 1000
@@ -154,7 +156,7 @@ defmodule Verk.WorkersManagerTest do
     expect(:poolboy, :checkout, [pool_name, false], worker)
     expect(Verk.Worker, :perform_async, [worker, worker, job], :ok)
 
-    assert handle_info(:timeout, state) == { :noreply, state, state.timeout }
+    assert handle_info(:timeout, state) == { :noreply, state, 1692 }
     assert match?([{^worker, ^job_id, ^job, _, _}], :ets.lookup(monitors, worker))
     assert_receive %Verk.Events.JobStarted{ job: ^job, started_at: _ }
 


### PR DESCRIPTION
To hopefully close https://github.com/edgurgel/verk/issues/38

I wasn't sure if there was a preferred way range for the random timeout, but this PR currently has it between 1x-2x as long as the configured timeout.

This makes testing a bit goofy, and there is probably a better way to handle it.