### PR TITLE
Fix bad stacktrace formatting

### DIFF
--- a/lib/verk/queue_manager.ex
+++ b/lib/verk/queue_manager.ex
@@ -131,7 +131,7 @@ defmodule Verk.QueueManager do
   end
 
   defp build_retry_job(job, retry_count, failed_at, exception, stacktrace) do
-    job = %{job | error_backtrace: Exception.format_stacktrace(stacktrace),
+    job = %{job | error_backtrace: format_stacktrace(stacktrace),
                   error_message: Exception.message(exception),
                   retry_count: retry_count}
     if retry_count > 1 do
@@ -155,4 +155,7 @@ defmodule Verk.QueueManager do
   defp inprogress(queue_name, node_id) do
     "inprogress:#{queue_name}:#{node_id}"
   end
+
+  defp format_stacktrace(stacktrace) when is_list(stacktrace), do: Exception.format_stacktrace(stacktrace)
+  defp format_stacktrace(stacktrace), do: inspect(stacktrace)
 end


### PR DESCRIPTION
I've had some pretty bad crashes from this (bringing down the entire verk application), and the root cause is from `System.stracktrace` [here](https://github.com/edgurgel/verk/blob/master/lib/verk/worker.ex#L40) returning a stacktrace like `{GenServer, :call, [:my_named_process, \"1\", 5000]}`.

Verk eventually attempts to format with `Exception.format_stacktrace/1` [here](https://github.com/edgurgel/verk/blob/master/lib/verk/queue_manager.ex#L134), which doesn't work since that calls `Enum.map_join`, and a tuple isn't Enumerable.

A contrived example of a worker that causes this:

```elixir
defmodule Verk.TestWorker do
  def perform(key_or_keys) do
    GenServer.call(:my_named_process, "1")
  end
end
```

I added a test that will fail without my changes:

```
  1) test call retry on a job with non-enum stacktrace (Verk.QueueManagerTest)
     test/queue_manager_test.exs:213
     ** (Protocol.UndefinedError) protocol Enumerable not implemented for {GenServer, :call, [:process, "1"]}
     stacktrace:
       (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
       (elixir) lib/enum.ex:116: Enumerable.reduce/3
       (elixir) lib/enum.ex:1486: Enum.reduce/3
       (elixir) lib/enum.ex:1118: Enum.map_join/3
       (elixir) lib/exception.ex:388: Exception.format_stacktrace/1
       (verk) lib/verk/queue_manager.ex:134: Verk.QueueManager.build_retry_job/5
       (verk) lib/verk/queue_manager.ex:122: Verk.QueueManager.handle_call/3
       test/queue_manager_test.exs:224
```

Beyond it's impact on verk here, I'm not sure if it's considered an Elixir issue that `System.stacktrace` may return something not necessarily formattable.