### PR TITLE
Change Verk application to not start Verk.Supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Feature set:
 * Reliable job processing (RPOPLPUSH and Lua scripts to the rescue)
 * Error and event tracking
 
-
 ## Installation
 
 First, add Verk to your `mix.exs` dependencies:
@@ -48,6 +47,21 @@ application dependency:
 ```elixir
 def application do
   [applications: [:verk]]
+end
+```
+
+Finally add `Verk.Supervisor` to your supervision tree:
+
+```elixir
+defmodule Example.App do
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec
+    tree = [supervisor(Verk.Supervisor, [])]
+    opts = [name: Simple.Sup, strategy: :one_for_one]
+    Supervisor.start_link(tree, opts)
+  end
 end
 ```
 

--- a/lib/verk.ex
+++ b/lib/verk.ex
@@ -8,15 +8,11 @@ defmodule Verk do
 
   It has an API that provides information about the queues
   """
-  use Application
   alias Verk.Job
   alias Timex.Time
   alias Timex.DateTime
 
   @schedule_key "schedule"
-
-  @doc false
-  def start(_type, _args), do: Verk.Supervisor.start_link
 
   @doc """
   Add a new `queue` with a pool of size `size` of workers

--- a/mix.exs
+++ b/mix.exs
@@ -20,8 +20,7 @@ defmodule Verk.Mixfile do
 
   def application do
     [applications: [:logger, :poison, :tzdata, :timex, :redix, :poolboy, :watcher],
-     env: [node_id: "1", redis_url: "redis://127.0.0.1:6379"],
-     mod: {Verk, []}]
+     env: [node_id: "1", redis_url: "redis://127.0.0.1:6379"]]
   end
 
   defp deps do


### PR DESCRIPTION
All the users will need to change their supervision trees to add `Verk.Supervisor`.

I'm glad we are not on 1.0.0 yet :)

It closes https://github.com/edgurgel/verk/issues/58