### PR TITLE
String.to_atom/1 may cause atom exhaust in worker's process

### DIFF
--- a/lib/verk/worker.ex
+++ b/lib/verk/worker.ex
@@ -33,7 +33,7 @@ defmodule Verk.Worker do
   def handle_cast({:perform, job, manager}, state) do
     try do
       :erlang.put(@process_dict_key, job)
-      apply(String.to_atom("Elixir.#{job.class}"), :perform, job.args)
+      apply(String.to_existing_atom("Elixir.#{job.class}"), :perform, job.args)
       GenServer.cast(manager, {:done, self, job.jid})
       {:stop, :normal, state}
     rescue


### PR DESCRIPTION
The apply modules must already be there~