### PR TITLE
Find class module by Module.safe_concat/1

### DIFF
--- a/lib/verk/worker.ex
+++ b/lib/verk/worker.ex
@@ -33,7 +33,7 @@ defmodule Verk.Worker do
   def handle_cast({:perform, job, manager}, state) do
     try do
       :erlang.put(@process_dict_key, job)
-      Module.safe_concat([job.class]) |> apply(:perform, job.args)
+      [job.class] |> Module.safe_concat |> apply(:perform, job.args)
       GenServer.cast(manager, {:done, self, job.jid})
       {:stop, :normal, state}
     rescue

--- a/lib/verk/worker.ex
+++ b/lib/verk/worker.ex
@@ -33,7 +33,7 @@ defmodule Verk.Worker do
   def handle_cast({:perform, job, manager}, state) do
     try do
       :erlang.put(@process_dict_key, job)
-      apply(String.to_atom("Elixir.#{job.class}"), :perform, job.args)
+      Module.safe_concat([job.class]) |> apply(:perform, job.args)
       GenServer.cast(manager, {:done, self, job.jid})
       {:stop, :normal, state}
     rescue

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -29,6 +29,24 @@ defmodule Verk.WorkerTest do
     assert_receive {:"$gen_cast", {:done, ^worker, "job_id"}}
   end
 
+  test "cast perform runs the specified atom module with the args succeding" do
+    worker = self
+    job = %Verk.Job{jid: "job_id", class: TestWorker, args: [worker]}
+    assert handle_cast({ :perform, job, worker }, :state) == { :stop, :normal, :state }
+
+    assert_receive :perform_executed
+    assert_receive {:"$gen_cast", {:done, ^worker, "job_id"}}
+  end
+
+  test "cast perform runs the no exist module with the args succeding" do
+    worker = self
+    job = %Verk.Job{jid: "job_id", class: TestWorkerNoExist, args: [worker]}
+    assert handle_cast({ :perform, job, worker }, :state) == { :stop, :failed, :state }
+
+    exception = %UndefinedFunctionError{arity: 1, function: :perform, module: TestWorkerNoExist, reason: nil}
+    assert_receive { :"$gen_cast", { :failed, ^worker, "job_id", ^exception, _ } }
+  end
+
   test "cast perform runs the specified module with the args failing" do
     worker = self
     job = %Verk.Job{jid: "job_id", class: "FailWorker", args: ["arg1"]}


### PR DESCRIPTION
if just use String.to_existing_atom/1
```
%Verk.Job{class: ModuleAtom.Name}
will be change to 
"Elixir.Elixir.ModuleAtom.Name" |> String.to_existing_atom
```
so we better use Module.safe_concat/1 to add Elixir prefix 

：）
Thanks for the great project~