### PR TITLE
Configurable max_retry_count

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ end
 This job can be enqueued using `Verk.enqueue/1`:
 
 ```elixir
-Verk.enqueue(%Verk.Job{queue: :default, class: "ExampleWorker", args: [1,2]})
+Verk.enqueue(%Verk.Job{queue: :default, class: "ExampleWorker", args: [1,2], max_retry_count: 5})
 ```
 
 This job can also be scheduled using `Verk.schedule/2`:
@@ -100,6 +100,7 @@ The queue `default` will have a maximum of 25 jobs being processed at a time and
 
 ```elixir
 config :verk, queues: [default: 25, priority: 10],
+              max_retry_count: 10,
               poll_interval: 5000,
               node_id: "1",
               redis_url: "redis://127.0.0.1:6379"

--- a/lib/verk.ex
+++ b/lib/verk.ex
@@ -49,7 +49,7 @@ defmodule Verk do
     job = %Job{job | max_retry_count: Job.default_max_retry_count()}
     enqueue(job, redis)
   end
-  def enqueue(job = %Job{max_retry_count: count}, _redis) when not is_integer(count), do: {:error, {:missing_args, job}}
+  def enqueue(job = %Job{max_retry_count: count}, _redis) when not is_integer(count), do: {:error, {:invalid_max_retry_count, job}}
   def enqueue(job = %Job{jid: nil}, redis), do: enqueue(%Job{job | jid: generate_jid}, redis)
   def enqueue(%Job{jid: jid, queue: queue} = job, redis) do
     case Redix.command(redis, ["LPUSH", "queue:#{queue}", Poison.encode!(job)]) do

--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -5,7 +5,8 @@ defmodule Verk.Job do
 
   @default_max_retry_count Application.get_env(:verk, :max_retry_count, 25)
   @keys [error_message: nil, failed_at: nil, retry_count: 0, queue: nil, class: nil, args: [],
-         jid: nil, finished_at: nil, enqueued_at: nil, retried_at: nil, error_backtrace: nil, max_retry_count: @default_max_retry_count]
+         jid: nil, finished_at: nil, enqueued_at: nil, retried_at: nil, error_backtrace: nil,
+         max_retry_count: @default_max_retry_count]
 
   @derive {Poison.Encoder, only: Keyword.keys(@keys)}
   defstruct [:original_json | @keys]

--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -4,8 +4,9 @@ defmodule Verk.Job do
   """
 
   @keys [error_message: nil, failed_at: nil, retry_count: 0, queue: nil, class: nil, args: [],
-         jid: nil, finished_at: nil, enqueued_at: nil, retried_at: nil, error_backtrace: nil]
+         jid: nil, finished_at: nil, enqueued_at: nil, retried_at: nil, error_backtrace: nil, max_retry_count: @default_max_retry_count]
 
+  @default_max_retry_count 25
   @derive {Poison.Encoder, only: Keyword.keys(@keys)}
   defstruct [:original_json | @keys]
 

--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -3,10 +3,10 @@ defmodule Verk.Job do
   The Job struct
   """
 
+  @default_max_retry_count Application.get_env(:verk, :max_retry_count, 25)
   @keys [error_message: nil, failed_at: nil, retry_count: 0, queue: nil, class: nil, args: [],
          jid: nil, finished_at: nil, enqueued_at: nil, retried_at: nil, error_backtrace: nil, max_retry_count: @default_max_retry_count]
 
-  @default_max_retry_count 25
   @derive {Poison.Encoder, only: Keyword.keys(@keys)}
   defstruct [:original_json | @keys]
 
@@ -17,5 +17,9 @@ defmodule Verk.Job do
   def decode!(payload) do
     job = Poison.decode!(payload, as: %__MODULE__{})
     %Verk.Job{job | original_json: payload}
+  end
+
+  def default_max_retry_count do
+    @default_max_retry_count
   end
 end

--- a/test/job_test.exs
+++ b/test/job_test.exs
@@ -3,8 +3,9 @@ defmodule Verk.JobTest do
   alias Verk.Job
 
   test "decode! includes original json" do
-    payload = "{ \"queue\" : \"test_queue\", \"args\" : [1, 2, 3] }"
+    payload = ~s({ "queue" : "test_queue", "args" : [1, 2, 3],
+                 "max_retry_count" : 5})
 
-    assert Job.decode!(payload) == %Job{ queue: "test_queue", args: [1, 2, 3], original_json: payload }
+    assert Job.decode!(payload) == %Job{ queue: "test_queue", args: [1, 2, 3], original_json: payload, max_retry_count: 5}
   end
 end

--- a/test/verk_test.exs
+++ b/test/verk_test.exs
@@ -118,6 +118,13 @@ defmodule VerkTest do
     assert enqueue(job) == { :error, { :missing_module, job } }
   end
 
+  test "enqueue a job with non-integer max_retry_count" do
+    job = %Verk.Job{ queue: "queue", jid: "job_id", class: "TestWorker",
+      args: 123, max_retry_count: "30" }
+
+    assert enqueue(job) == { :error, { :missing_args, job } }
+  end
+
   test "schedule a job with a jid, a queue and a perform_in" do
     now = Time.now
     perform_at = Time.shift(now, 100)

--- a/test/verk_test.exs
+++ b/test/verk_test.exs
@@ -120,9 +120,9 @@ defmodule VerkTest do
 
   test "enqueue a job with non-integer max_retry_count" do
     job = %Verk.Job{ queue: "queue", jid: "job_id", class: "TestWorker",
-      args: 123, max_retry_count: "30" }
+      args: [123], max_retry_count: "30" }
 
-    assert enqueue(job) == { :error, { :missing_args, job } }
+    assert enqueue(job) == { :error, { :invalid_max_retry_count, job } }
   end
 
   test "schedule a job with a jid, a queue and a perform_in" do

--- a/test/verk_test.exs
+++ b/test/verk_test.exs
@@ -53,7 +53,8 @@ defmodule VerkTest do
   end
 
   test "enqueue a job with a jid and a queue passing redis connection" do
-    job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker", args: [] }
+    job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker",
+      args: [], max_retry_count: 1 }
     encoded_job = "encoded_job"
     expect(Poison, :encode!, [job], encoded_job)
     expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })
@@ -64,7 +65,8 @@ defmodule VerkTest do
   end
 
   test "enqueue a job with a jid and a queue passing no redis connection" do
-    job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker", args: [] }
+    job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker",
+      args: [], max_retry_count: 1 }
     encoded_job = "encoded_job"
     expect(Poison, :encode!, [job], encoded_job)
     expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })
@@ -75,7 +77,8 @@ defmodule VerkTest do
   end
 
   test "enqueue a job with a jid and a queue" do
-    job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker", args: [] }
+    job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker",
+      args: [], max_retry_count: 1 }
     encoded_job = "encoded_job"
     expect(Poison, :encode!, [job], encoded_job)
     expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })


### PR DESCRIPTION
For #81 

Allows for configuring a global max_retry_count with:
```elixir
config :verk,
  max_retry_count: 1
```

Or when the job is added:
```elixir
Verk.enqueue(%Verk.Job{ queue: "queue", jid: "job_id", class: "TestWorker",
      args: 123, max_retry_count: 10 })
```

But otherwise continues to default to 25

