### PR TITLE
Add method for persisted queue stats

### DIFF
--- a/lib/verk/stats.ex
+++ b/lib/verk/stats.ex
@@ -12,6 +12,15 @@ defmodule Verk.Stats do
     %{processed: to_int(processed), failed: to_int(failed)}
   end
 
+  @doc """
+  Total amount of processed and failed jobs for a single queue
+  """
+  @spec queue_total(String.t, GenServer.server) :: Map.t
+  def queue_total(queue, redis \\ Verk.Redis) do
+    [processed, failed] = Redix.command!(redis, ~w(MGET stat:processed:#{queue} stat:failed:#{queue}))
+    %{total_processed: to_int(processed), total_failed: to_int(failed)}
+  end
+
   defp to_int(nil), do: 0
   defp to_int(string), do: String.to_integer(string)
 end

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -7,6 +7,7 @@ defmodule Verk.StatsTest do
                        |> elem(1)
                        |> Redix.start_link
     Redix.command!(redis, ~w(DEL stat:processed stat:failed))
+    Redix.command!(redis, ~w(DEL stat:processed:default stat:failed:default))
     { :ok, redis: redis }
   end
 
@@ -19,6 +20,18 @@ defmodule Verk.StatsTest do
       Redix.command!(redis, ~w(MSET stat:processed 25 stat:failed 32))
 
       assert total(redis) == %{ processed: 25, failed: 32 }
+    end
+  end
+
+  describe "queue_total/2" do
+    test "with no data", %{ redis: redis } do
+      assert queue_total("default", redis) == %{total_processed: 0, total_failed: 0}
+    end
+
+    test "with data", %{ redis: redis } do
+      Redix.command!(redis, ~w(MSET stat:processed:default 25 stat:failed:default 32))
+
+      assert queue_total("default", redis) == %{total_processed: 25, total_failed: 32}
     end
   end
 end


### PR DESCRIPTION
Also see: https://github.com/edgurgel/verk_web/pull/27

This PR adds an additional method to `lib/verk/stats.ex` that returns total processed/failed job counts for every queue in the format:

```
%{<queue> => %{total_finished: <# finished>, total_failed: <# failed>}, ...}
```