### PR TITLE
Remove unused @max_dead constant in queue_manager.ex

### DIFF
--- a/lib/verk/queue_manager.ex
+++ b/lib/verk/queue_manager.ex
@@ -15,7 +15,6 @@ defmodule Verk.QueueManager do
   @lpop_rpush_src_dest_script_sha Verk.Scripts.sha("lpop_rpush_src_dest")
   @mrpop_lpush_src_dest_script_sha Verk.Scripts.sha("mrpop_lpush_src_dest")
 
-  @max_dead 100
   @max_jobs 100
 
   defmodule State do


### PR DESCRIPTION
This constant doesn't seem to be used anywhere.