### PR TITLE
Add {SortedSet,RetrySet}.range_with_score/3

### DIFF
--- a/lib/verk/retry_set.ex
+++ b/lib/verk/retry_set.ex
@@ -86,6 +86,22 @@ defmodule Verk.RetrySet do
   end
 
   @doc """
+  List jobs from `start` to `stop` including their scores
+  """
+  @spec range_with_score(integer, integer, GenServer.server) :: {:ok, [{Verk.Job.T, integer}]} | {:error, Redix.Error.t}
+  def range_with_score(start \\ 0, stop \\ -1, redis \\ Verk.Redis) do
+    SortedSet.range_with_score(@retry_key, start, stop, redis)
+  end
+
+  @doc """
+  List jobs from `start` to `stop` including their scores, raising if there's an error
+  """
+  @spec range_with_score!(integer, integer, GenServer.server) :: [{Verk.Job.T, integer}]
+  def range_with_score!(start \\ 0, stop \\ -1, redis \\ Verk.Redis) do
+    SortedSet.range_with_score!(@retry_key, start, stop, redis)
+  end
+
+  @doc """
   Delete the job from the retry set
 
   It returns `{:ok, true}` if the job was found and deleted

--- a/test/retry_set_test.exs
+++ b/test/retry_set_test.exs
@@ -110,6 +110,42 @@ defmodule Verk.RetrySetTest do
     end
   end
 
+  describe "range_with_score/0" do
+    test "range_with_score" do
+      job = %Verk.Job{class: "Class", args: []}
+      json = Poison.encode!(job)
+
+      expect(SortedSet, :range_with_score, [key, 0, -1, Verk.Redis], {:ok, [{%{ job | original_json: json }, 45}]})
+
+      assert range_with_score == {:ok, [{%{ job | original_json: json }, 45}]}
+      assert validate SortedSet
+    end
+  end
+
+  describe "range_with_score/2" do
+    test "range_with_score with start and stop" do
+      job = %Verk.Job{class: "Class", args: []}
+      json = Poison.encode!(job)
+
+      expect(SortedSet, :range_with_score, [key, 1, 2, Verk.Redis], {:ok, [{%{ job | original_json: json }, 45}]})
+
+      assert range_with_score(1, 2) == {:ok, [{%{ job | original_json: json }, 45}]}
+      assert validate SortedSet
+    end
+  end
+
+  describe "range_with_score!/0" do
+    test "range_with_score!" do
+      job = %Verk.Job{class: "Class", args: []}
+      json = Poison.encode!(job)
+
+      expect(SortedSet, :range_with_score!, [key, 0, -1, Verk.Redis], [{%{ job | original_json: json }, 45}])
+
+      assert range_with_score! == [{%{ job | original_json: json }, 45}]
+      assert validate SortedSet
+    end
+  end
+
   describe "delete_job/1" do
     test "job with original_json" do
       job = %Verk.Job{class: "Class", args: []}

--- a/test/sorted_set_test.exs
+++ b/test/sorted_set_test.exs
@@ -86,6 +86,34 @@ defmodule Verk.SortedSetTest do
     end
   end
 
+  describe "range_with_score/2" do
+    test "with items", %{ redis: redis } do
+      job = %Verk.Job{class: "Class", args: []}
+      json = Poison.encode!(job)
+      Redix.command!(redis, ~w(ZADD sorted 123 #{json}))
+
+      assert range_with_score("sorted", redis) == {:ok, [{%{ job | original_json: json }, 123}]}
+    end
+
+    test "with no items", %{ redis: redis } do
+      assert range_with_score("sorted", redis) == {:ok, []}
+    end
+  end
+
+  describe "range_with_score!/2" do
+    test "with items", %{ redis: redis } do
+      job = %Verk.Job{class: "Class", args: []}
+      json = Poison.encode!(job)
+      Redix.command!(redis, ~w(ZADD sorted 123 #{json}))
+
+      assert range_with_score("sorted", redis) == {:ok, [{%{ job | original_json: json }, 123}]}
+    end
+
+    test "with no items", %{ redis: redis } do
+      assert range_with_score!("sorted", redis) == []
+    end
+  end
+
   describe "delete_job/3" do
     test "with job", %{ redis: redis } do
       job = %Verk.Job{class: "Class", args: []}


### PR DESCRIPTION
This additional method allows for listing jobs by their precedence within a Redis set. This can be useful for determining when a job will next be attempted or when a dead job was declared dead, among other possible uses.