### PR TITLE
Rescue JSON decoding errors rather than killing WorkerManager

### DIFF
--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -14,6 +14,17 @@ defmodule Verk.Job do
   @doc """
   Decode the JSON payload storing the original json as part of the struct.
   """
+  @spec decode(binary) :: {:ok, %__MODULE__{}} | {:error, Poison.Error.t}
+  def decode(payload) do
+    case Poison.decode(payload, as: %__MODULE__{}) do
+      {:ok, job} -> {:ok, %Verk.Job{job | original_json: payload}}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  @doc """
+  Decode the JSON payload storing the original json as part of the struct, raising if there is an error
+  """
   @spec decode!(binary) :: %__MODULE__{}
   def decode!(payload) do
     job = Poison.decode!(payload, as: %__MODULE__{})

--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -104,7 +104,7 @@ defmodule Verk.WorkersManager do
               {:ok, verk_job} -> start_job(verk_job, state)
               {:error, error} ->
                 Logger.error("Failed to decode job, error: #{inspect error}, original job: #{inspect job}")
-                QueueManager.ack(state.queue_manager_name, job)
+                QueueManager.malformed(state.queue_manager_name, job)
             end
           end)
         reason ->

--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -99,7 +99,14 @@ defmodule Verk.WorkersManager do
     if workers != 0 do
       case QueueManager.dequeue(state.queue_manager_name, workers) do
         jobs when is_list(jobs) ->
-          for job <- jobs, do: job |> Job.decode! |> start_job(state)
+          Enum.each(jobs, fn job ->
+            case job |> Job.decode do
+              {:ok, verk_job} -> start_job(verk_job, state)
+              {:error, error} ->
+                Logger.error("Failed to decode job, error: #{inspect error}, original job: #{inspect job}")
+                QueueManager.ack(state.queue_manager_name, job)
+            end
+          end)
         reason ->
           Logger.error("Failed to fetch a job. Reason: #{inspect reason}")
       end

--- a/test/job_test.exs
+++ b/test/job_test.exs
@@ -10,4 +10,20 @@ defmodule Verk.JobTest do
       assert Job.decode!(payload) == %Job{ queue: "test_queue", args: [1, 2, 3], original_json: payload, max_retry_count: 5}
     end
   end
+
+  describe "decode/1" do
+    test "includes original json" do
+      payload = ~s({ "queue" : "test_queue", "args" : [1, 2, 3],
+                   "max_retry_count" : 5})
+
+      assert Job.decode(payload) == {:ok, %Job{ queue: "test_queue", args: [1, 2, 3], original_json: payload, max_retry_count: 5}}
+    end
+
+    test "json decode error returns error tuple" do
+      payload = ~s({ "queue" : "test_queue", "args" : [1, 2, [[{{],
+                   "max_retry_count" : 5})
+
+      assert {:error, _} = Job.decode(payload)
+    end
+  end
 end

--- a/test/queue_manager_test.exs
+++ b/test/queue_manager_test.exs
@@ -250,5 +250,17 @@ defmodule Verk.QueueManagerTest do
 
       assert validate Redix
     end
+
+    test "malformed job" do
+      job = ""
+
+      expect(Redix, :command, [:redis, ["LREM", "inprogress:test_queue:test_node", "-1", job]], { :ok, 1 })
+
+      state = %State{ queue_name: "test_queue", redis: :redis, node_id: "test_node" }
+
+      assert handle_cast({ :malformed, job}, state) == { :noreply, state }
+
+      assert validate Redix
+    end
   end
 end


### PR DESCRIPTION
This is a first pass at addressing https://github.com/edgurgel/verk/issues/89. I was initially unsure of how to skip jobs because `QueueManager.dequeue`will have already moved them to the `inprogress` queue. But calling `QueueManager.ack` will remove it.

It might be cleaner to add a new handler to `QueueManager` that does the same thing as `:ack` but is explicitly used for removal (whereas using `:ack` seems to imply removal of a successfully completed job).

It is pretty difficult to add a test for this as enqueuing jobs from Verk uses Poison encoding and thus the interoperability problem I am running into cannot be recreated easily.