### PR TITLE
Typo in error tracking docs supervision tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ You also need to add the handler to connect with the event manager. You can do t
     def start(_type, _args) do
       import Supervisor.Spec
       tree = [supervisor(Verk.Supervisor, []),
-              worker(TrackingErrorHandler, [Verk.EventManager])]
+              worker(TrackingErrorHandlerServer, [Verk.EventManager])]
       opts = [name: Simple.Sup, strategy: :one_for_one]
       Supervisor.start_link(tree, opts)
     end


### PR DESCRIPTION
I was just reading over the docs and realized I made a typo here. We need to add the GenServer to the supervision tree not the handler itself.