### PR TITLE
Configure log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ The queue `default` will have a maximum of 25 jobs being processed at a time and
 config :verk, queues: [default: 25, priority: 10],
               max_retry_count: 10,
               poll_interval: 5000,
+              start_job_log_level: :info,
+              done_job_log_level: :info,
+              fail_job_log_level: :info,
               node_id: "1",
               redis_url: "redis://127.0.0.1:6379"
 ```

--- a/lib/verk/log.ex
+++ b/lib/verk/log.ex
@@ -8,15 +8,21 @@ defmodule Verk.Log do
   alias Verk.{Job, Time}
 
   def start(%Job{jid: job_id, class: module}, process_id) do
-    info("#{module} #{job_id} start", process_id: inspect(process_id))
+    :verk
+    |> Application.get_env(:start_job_log_level, :info)
+    |> log("#{module} #{job_id} start", process_id: inspect(process_id))
   end
 
   def done(%Job{jid: job_id, class: module}, start_time, process_id) do
-    info("#{module} #{job_id} done: #{elapsed_time(start_time)}", process_id: inspect(process_id))
+    :verk
+    |> Application.get_env(:done_job_log_level, :info)
+    |> log("#{module} #{job_id} done: #{elapsed_time(start_time)}", process_id: inspect(process_id))
   end
 
   def fail(%Job{jid: job_id, class: module}, start_time, process_id) do
-    info("#{module} #{job_id} fail: #{elapsed_time(start_time)}", process_id: inspect(process_id))
+    :verk
+    |> Application.get_env(:fail_job_log_level, :info)
+    |> log("#{module} #{job_id} fail: #{elapsed_time(start_time)}", process_id: inspect(process_id))
   end
 
   defp elapsed_time(start_time) do


### PR DESCRIPTION
This PR addresses https://github.com/edgurgel/verk/issues/66 using the `Logger.log/3` method discussed in that issue.

This has the tradeoff of being less verbose but not taking advantage of compile time optimization of logging calls that would happen using a method such as the one proposed in my earlier comment https://github.com/edgurgel/verk/issues/66#issuecomment-260406840.