### PR TITLE
Add [SortedSet,RetrySet].requeue_job for on-demand job retries

### DIFF
--- a/lib/verk/retry_set.ex
+++ b/lib/verk/retry_set.ex
@@ -128,4 +128,32 @@ defmodule Verk.RetrySet do
     delete_job!(original_json, redis)
   end
   def delete_job!(original_json, redis), do: SortedSet.delete_job!(@retry_key, original_json, redis)
+
+  @doc """
+  Move the job out of the retry set to be retried immediately
+
+  It returns `{:ok, true}` if the job was found and requeued
+  Otherwise it returns `{:ok, false}`
+
+  An error tuple may be returned if Redis failed
+  """
+  @spec requeue_job(%Job{} | String.t, GenServer.server) :: {:ok, boolean}| {:error, Redix.Error.t}
+  def requeue_job(original_json, redis \\ Verk.Redis)
+  def requeue_job(%Job{original_json: original_json}, redis) do
+    requeue_job(original_json, redis)
+  end
+  def requeue_job(original_json, redis), do: SortedSet.requeue_job(@retry_key, original_json, redis)
+
+  @doc """
+  Move the job out of the retry set to be retried immediately, raising if there's an error
+
+  It returns `true` if the job was found and requeued
+  Otherwise it returns `false`
+  """
+  @spec requeue_job!(%Job{} | String.t, GenServer.server) :: boolean
+  def requeue_job!(original_json, redis \\ Verk.Redis)
+  def requeue_job!(%Job{original_json: original_json}, redis) do
+    requeue_job!(original_json, redis)
+  end
+  def requeue_job!(original_json, redis), do: SortedSet.requeue_job!(@retry_key, original_json, redis)
 end

--- a/lib/verk/sorted_set.ex
+++ b/lib/verk/sorted_set.ex
@@ -5,6 +5,8 @@ defmodule Verk.SortedSet do
   import Verk.Dsl
   alias Verk.Job
 
+  @requeue_now_script Verk.Scripts.sha("requeue_job_now")
+
   @doc """
   Counts how many jobs are inside the sorted set
   """
@@ -127,5 +129,44 @@ defmodule Verk.SortedSet do
 
   def delete_job!(key, original_json, redis) do
     bangify(delete_job(key, original_json, redis))
+  end
+
+  @doc """
+  Moves the job from the sorted set back to its original queue
+
+  It returns `{:ok, true}` if the job was found and requeued
+  Otherwise it returns `{:ok, false}`
+
+  An error tuple may be returned if Redis failed
+  """
+  @spec requeue_job(String.t, %Job{} | String.t, GenServer.server) :: {:ok, boolean} | {:error, Redix.Error.t}
+  def requeue_job(key, %Job{original_json: original_json}, redis) do
+    requeue_job(key, original_json, redis)
+  end
+
+  def requeue_job(key, original_json, redis) do
+    case Redix.command(redis, ["EVALSHA", @requeue_now_script, 1, key, original_json]) do
+      {:ok, nil} -> {:ok, false}
+      {:ok, _job} -> {:ok, true}
+      {:error, %Redix.Error{message: message}} ->
+        {:error, message}
+      error ->
+        {:error, error}
+    end
+  end
+
+  @doc """
+  Moves the job from the sorted set back to its original queue, raising if there's an error
+
+  It returns `true` if the job was found and requeued
+  Otherwise it returns `false`
+  """
+  @spec requeue_job!(String.t, %Job{} | String.t, GenServer.server) :: boolean
+  def requeue_job!(key, %Job{original_json: original_json}, redis) do
+    requeue_job!(key, original_json, redis)
+  end
+
+  def requeue_job!(key, original_json, redis) do
+    bangify(requeue_job(key, original_json, redis))
   end
 end

--- a/priv/requeue_job_now.lua
+++ b/priv/requeue_job_now.lua
@@ -1,0 +1,22 @@
+local job = ARGV[1]
+
+if job then
+  -- The job contents are already available, find the destination queue name.
+  local queue = cjson.decode(job)["queue"]
+  if queue then
+    local queue_key = string.format('queue:%s', queue)
+
+    -- Don't requeue the job unless its removal from current sorted set
+    -- can be confirmed.
+    local removed = redis.call("ZREM", KEYS[1], job)
+    if removed == 1 then
+      redis.call("LPUSH", queue_key, job)
+    else
+      -- Signifies that the job was not present in the initial queue
+      -- and so no work was done.
+      return nil
+    end
+  end
+end
+
+return job

--- a/test/redis_scripts_test.exs
+++ b/test/redis_scripts_test.exs
@@ -4,6 +4,7 @@ defmodule RedisScriptsTest do
   @lpop_rpush_src_dest_script File.read!("#{:code.priv_dir(:verk)}/lpop_rpush_src_dest.lua")
   @mrpop_lpush_src_dest_script File.read!("#{:code.priv_dir(:verk)}/mrpop_lpush_src_dest.lua")
   @enqueue_retriable_job_script File.read!("#{:code.priv_dir(:verk)}/enqueue_retriable_job.lua")
+  @requeue_job_now_script File.read!("#{:code.priv_dir(:verk)}/requeue_job_now.lua")
 
   setup do
     { :ok, redis } = Application.fetch_env(:verk, :redis_url)
@@ -51,11 +52,41 @@ defmodule RedisScriptsTest do
       { :ok, _ } = Redix.command(redis, ~w(ZADD retry 42 #{job} 45 #{other_job}))
       { :ok, _ } = Redix.command(redis, ~w(LPUSH queue:test_queue #{enqueued_job}))
 
-      assert Redix.command(redis, ["EVAL", @enqueue_retriable_job_script, 1, "retry", "41"]) == {:ok, nil }
-      assert Redix.command(redis, ["EVAL", @enqueue_retriable_job_script, 1, "retry", "42"]) == {:ok, job }
+      assert Redix.command(redis, ["EVAL", @enqueue_retriable_job_script, 1, "retry", "41"]) == { :ok, nil }
+      assert Redix.command(redis, ["EVAL", @enqueue_retriable_job_script, 1, "retry", "42"]) == { :ok, job }
 
       assert Redix.command(redis, ~w(ZRANGEBYSCORE retry -inf +inf WITHSCORES)) == { :ok, [other_job, "45"] }
       assert Redix.command(redis, ~w(LRANGE queue:test_queue 0 -1)) == { :ok, [job, enqueued_job] }
+    end
+  end
+
+  describe "requeue_job_now" do
+    test "improper job format returns job data doesn't move job", %{ redis: redis } do
+      job_with_no_queue = "{\"jid\":\"123\"}"
+      { :ok, _ } = Redix.command(redis, ~w(DEL retry queue:test_queue))
+      { :ok, _ } = Redix.command(redis, ~w(ZADD retry 42 #{job_with_no_queue}))
+
+      assert Redix.command(redis, ["EVAL", @requeue_job_now_script, 1, "retry", job_with_no_queue]) == {:ok, job_with_no_queue}
+      assert Redix.command(redis, ~w(ZRANGEBYSCORE retry -inf +inf WITHSCORES)) == { :ok, [job_with_no_queue, "42"] }
+    end
+
+    test "valid job format, requeue job moves from retry to original queue", %{ redis: redis } do
+      job = "{\"jid\":\"123\",\"queue\":\"test_queue\"}"
+      { :ok, _ } = Redix.command(redis, ~w(DEL retry queue:test_queue))
+      { :ok, _ } = Redix.command(redis, ~w(ZADD retry 42 #{job}))
+
+      assert Redix.command(redis, ~w(ZRANGEBYSCORE retry -inf +inf WITHSCORES)) == { :ok, [job, "42"] }
+      assert Redix.command(redis, ["EVAL", @requeue_job_now_script, 1, "retry", job]) == { :ok, job }
+      assert Redix.command(redis, ~w(ZRANGEBYSCORE retry -inf +inf WITHSCORES)) == { :ok, [] }
+    end
+
+    test "valid job format, empty original queue returns nil", %{ redis: redis } do
+      job = "{\"jid\":\"123\",\"queue\":\"test_queue\"}"
+      { :ok, _ } = Redix.command(redis, ~w(DEL retry queue:test_queue))
+
+      assert Redix.command(redis, ~w(ZRANGEBYSCORE retry -inf +inf WITHSCORES)) == { :ok, [] }
+      assert Redix.command(redis, ["EVAL", @requeue_job_now_script, 1, "retry", job]) == { :ok, nil }
+      assert Redix.command(redis, ~w(ZRANGEBYSCORE retry -inf +inf WITHSCORES)) == { :ok, [] }
     end
   end
 end

--- a/test/retry_set_test.exs
+++ b/test/retry_set_test.exs
@@ -187,4 +187,46 @@ defmodule Verk.RetrySetTest do
       assert validate SortedSet
     end
   end
+
+  describe "requeue_job/1" do
+    test "job with original_json" do
+      job = %Verk.Job{class: "Class", args: []}
+      json = Poison.encode!(job)
+      job = %{ job | original_json: json }
+
+      expect(SortedSet, :requeue_job, [key, json, Verk.Redis], :ok)
+
+      assert requeue_job(job) == :ok
+      assert validate SortedSet
+    end
+
+    test "job with no original_json" do
+      json = %Verk.Job{class: "Class", args: []} |> Poison.encode!
+      expect(SortedSet, :requeue_job, [key, json, Verk.Redis], {:ok, true})
+
+      assert requeue_job(json) == {:ok, true}
+      assert validate SortedSet
+    end
+  end
+
+  describe "requeue_job!/1" do
+    test "job with original_json" do
+      job = %Verk.Job{class: "Class", args: []}
+      json = Poison.encode!(job)
+      job = %{ job | original_json: json }
+
+      expect(SortedSet, :requeue_job!, [key, json, Verk.Redis], true)
+
+      assert requeue_job!(job) == true
+      assert validate SortedSet
+    end
+
+    test "job with no original_json" do
+      json = %Verk.Job{class: "Class", args: []} |> Poison.encode!
+      expect(SortedSet, :requeue_job!, [key, json, Verk.Redis], true)
+
+      assert requeue_job!(json) == true
+      assert validate SortedSet
+    end
+  end
 end


### PR DESCRIPTION
This PR is a first pass at adding the necessary Verk changes required to support on-demand job retrying for jobs in the retry queue (see: https://github.com/edgurgel/verk_web/issues/11).

The implementation is fairly self-explanatory, it primarily follows the patterns used in [enqueue_retriable_job.lua](https://github.com/edgurgel/verk/blob/master/priv/enqueue_retriable_job.lua) as well as [SortedSet.delete](https://github.com/edgurgel/verk/blob/c252802a095efe786c48299898b1f249d8108064/lib/verk/sorted_set.ex#L109-L114).

I expect that the change for https://github.com/edgurgel/verk_web/issues/11 will simply be the addition of another button (as for "Delete") that calls `RetrySet.requeue_job` in the controller ([as for "Delete"](https://github.com/edgurgel/verk_web/blob/bc0d71888944b1490e49a5a051f5711b65a66a49/web/controllers/retries_controller.ex#L18-L24)).

Not sure about the implementation so let me know your thoughts!