### PR TITLE
Change Verk.QueueStats.all to search for a prefix

### DIFF
--- a/lib/verk/queue_stats.ex
+++ b/lib/verk/queue_stats.ex
@@ -15,12 +15,12 @@ defmodule Verk.QueueStats do
   @persist_interval 10_000
 
   @doc """
-  Lists the queues and their stats
+  Lists the queues and their stats searching for a `prefix` if provided
   """
-  @spec all :: Map.t
-  def all do
-    for {queue, running, finished, failed} <- QueueStatsCounters.all, is_binary(queue) do
-      %{queue: queue, running_counter: running, finished_counter: finished, failed_counter: failed}
+  @spec all(binary) :: Map.t
+  def all(prefix \\ "") do
+    for {queue, running, finished, failed} <- QueueStatsCounters.all(prefix), is_list(queue) do
+      %{queue: to_string(queue), running_counter: running, finished_counter: finished, failed_counter: failed}
     end
   end
 


### PR DESCRIPTION
Searching for a prefix helps a lot when you have lots of different queues. 
This is useful if you have lots of different queues. 

The Verk Web part is coming soon 🔜 