### PR TITLE
Change LPUSH/ZREM command execution order in requeue_job_now script

### DIFF
--- a/priv/requeue_job_now.lua
+++ b/priv/requeue_job_now.lua
@@ -6,14 +6,13 @@ if job then
   if queue then
     local queue_key = string.format('queue:%s', queue)
 
-    -- Don't requeue the job unless its removal from current sorted set
-    -- can be confirmed.
-    local removed = redis.call("ZREM", KEYS[1], job)
-    if removed == 1 then
-      redis.call("LPUSH", queue_key, job)
+    -- Don't requeue the job unless it has been added to the destination queue.
+    local added = redis.call("LPUSH", queue_key, job)
+    if added ~= 0 then
+      redis.call("ZREM", KEYS[1], job)
     else
-      -- Signifies that the job was not present in the initial queue
-      -- and so no work was done.
+      -- Signifies that the job could not be added to the destination
+      -- queue and no work was done.
       return nil
     end
   end

--- a/test/redis_scripts_test.exs
+++ b/test/redis_scripts_test.exs
@@ -80,12 +80,12 @@ defmodule RedisScriptsTest do
       assert Redix.command(redis, ~w(ZRANGEBYSCORE retry -inf +inf WITHSCORES)) == { :ok, [] }
     end
 
-    test "valid job format, empty original queue returns nil", %{ redis: redis } do
+    test "valid job format, empty original queue job is still requeued", %{ redis: redis } do
       job = "{\"jid\":\"123\",\"queue\":\"test_queue\"}"
       { :ok, _ } = Redix.command(redis, ~w(DEL retry queue:test_queue))
 
       assert Redix.command(redis, ~w(ZRANGEBYSCORE retry -inf +inf WITHSCORES)) == { :ok, [] }
-      assert Redix.command(redis, ["EVAL", @requeue_job_now_script, 1, "retry", job]) == { :ok, nil }
+      assert Redix.command(redis, ["EVAL", @requeue_job_now_script, 1, "retry", job]) == { :ok, job }
       assert Redix.command(redis, ~w(ZRANGEBYSCORE retry -inf +inf WITHSCORES)) == { :ok, [] }
     end
   end


### PR DESCRIPTION
This PR reorders the data manipulation commands in the requeue_job_now.lua script in order to ensure an "at least once" execution guarantee.

See https://github.com/edgurgel/verk/issues/98 for a longer discussion.