### PR TITLE
Fix QueueStats GenEvent

### DIFF
--- a/lib/verk/queue_stats.ex
+++ b/lib/verk/queue_stats.ex
@@ -71,4 +71,9 @@ defmodule Verk.QueueStats do
     Process.send_after(self, :persist_stats, @persist_interval)
     {:ok, state}
   end
+
+  @doc false
+  def handle_info(_, state) do
+    {:ok, state}
+  end
 end

--- a/test/queue_stats_test.exs
+++ b/test/queue_stats_test.exs
@@ -144,5 +144,10 @@ defmodule Verk.QueueStatsTest do
         "2", "1"
       ]
     end
+
+    test 'test with unexpected message' do
+      init([])
+      assert handle_info(:pretty_sweet, :state) == {:ok, :state}
+    end
   end
 end


### PR DESCRIPTION
It needs to have a default handle_info otherwise any other GenEvent message can raise exceptions.