### PR TITLE
Batch enqueueing in_progress jobs via lpop_rpush script

### DIFF
--- a/lib/verk/queue_manager.ex
+++ b/lib/verk/queue_manager.ex
@@ -98,9 +98,13 @@ defmodule Verk.QueueManager do
   def handle_call(:enqueue_inprogress, _from, state) do
     in_progress_key = inprogress(state.queue_name, state.node_id)
     case Redix.command(state.redis, ["EVALSHA", @lpop_rpush_src_dest_script_sha, 2,
-                                     in_progress_key, "queue:#{state.queue_name}"]) do
+                                     in_progress_key, "queue:#{state.queue_name}", 1000]) do
+      {:ok, nil} ->
+        Logger.info("No jobs in queue #{state.queue_name} inprogress list")
+        {:reply, :ok, state}
       {:ok, n} ->
         Logger.info("#{n} jobs readded to the queue #{state.queue_name} from inprogress list")
+        Process.send(self, :enqueue_inprogress, [])
         {:reply, :ok, state}
       {:error, reason} ->
         Logger.error("Failed to add jobs back to queue #{state.queue_name} from inprogress. Error: #{inspect reason}")

--- a/test/queue_manager_test.exs
+++ b/test/queue_manager_test.exs
@@ -35,7 +35,7 @@ defmodule Verk.QueueManagerTest do
   describe "handle_call/3" do
     test "enqueue_inprogress" do
       script = Verk.Scripts.sha("lpop_rpush_src_dest")
-      expect(Redix, :command, [:redis, ["EVALSHA", script, 2, "inprogress:test_queue:test_node", "queue:test_queue"]], { :ok, 42 })
+      expect(Redix, :command, [:redis, ["EVALSHA", script, 2, "inprogress:test_queue:test_node", "queue:test_queue", 1000]], { :ok, 42 })
 
       state = %State{ queue_name: "test_queue", redis: :redis, node_id: "test_node" }
 
@@ -46,7 +46,7 @@ defmodule Verk.QueueManagerTest do
 
     test "enqueue_inprogress and redis failed" do
       script = Verk.Scripts.sha("lpop_rpush_src_dest")
-      expect(Redix, :command, [:redis, ["EVALSHA", script, 2, "inprogress:test_queue:test_node", "queue:test_queue"]], { :error, :reason })
+      expect(Redix, :command, [:redis, ["EVALSHA", script, 2, "inprogress:test_queue:test_node", "queue:test_queue", 1000]], { :error, :reason })
 
       state = %State{ queue_name: "test_queue", redis: :redis, node_id: "test_node" }
 

--- a/test/redis_scripts_test.exs
+++ b/test/redis_scripts_test.exs
@@ -20,7 +20,7 @@ defmodule RedisScriptsTest do
       { :ok, _ } = Redix.command(redis, ~w(RPUSH dest job1 job2 job3))
       { :ok, _ } = Redix.command(redis, ~w(LPUSH source job4 job5 job6))
 
-      assert Redix.command(redis, ["EVAL", @lpop_rpush_src_dest_script, 2, "source", "dest"]) == {:ok, 3 }
+      assert Redix.command(redis, ["EVAL", @lpop_rpush_src_dest_script, 2, "source", "dest", 1000]) == {:ok, 3 }
 
       assert Redix.command(redis, ~w(LRANGE source 0 -1)) == { :ok, [] }
       assert Redix.command(redis, ~w(LRANGE dest 0 -1)) == { :ok, ~w(job1 job2 job3 job6 job5 job4) }


### PR DESCRIPTION
First pass at addressing https://github.com/edgurgel/verk/issues/35

Just want to get some feedback on the approach. The primary issue I haven't addressed is that there is no `LPOPRPUSH` (see [this ticket](https://github.com/antirez/redis/issues/658)) so I chose to use `RPOPLPUSH` to get the atomic guarantee from Redis. I know this isn't ideal as it reorders jobs, but is this tradeoff worth the safety guarantee? Or should we just use `LPOP` -> `RPUSH`?

Also, might want to rename the script if we end up going with `LPOPRPUSH`.