### PR TITLE
GenStage

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,8 @@ config :verk,
   poll_interval: 5000,
   node_id: "1",
   redis_url: "redis://127.0.0.1:6379",
-  workers_manager_timeout: 1200
+  workers_manager_timeout: 1200,
+  use_gen_stage: false
   # failed_job_stacktrace_size: 5
 
 config :logger, :console,

--- a/lib/verk/events.ex
+++ b/lib/verk/events.ex
@@ -14,3 +14,30 @@ defmodule Verk.Events do
     defstruct [:job, :failed_at, :stacktrace, :exception]
   end
 end
+
+if Code.ensure_loaded?(GenStage) do
+  defmodule Verk.EventHandler do
+    use GenStage
+
+    def start_link do
+      GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
+    end
+
+    def async_notify(event) do
+      GenStage.cast(__MODULE__, {:notify, event})
+    end
+
+
+    def init(:ok) do
+      {:producer, :ok, dispatcher: GenStage.BroadcastDispatcher}
+    end
+
+    def handle_cast({:notify, event}, state) do
+      {:noreply, [event], state}
+    end
+
+    def handle_demand(_demand, state) do
+      {:noreply, [], state}
+    end
+  end
+end

--- a/lib/verk/events.ex
+++ b/lib/verk/events.ex
@@ -17,6 +17,9 @@ end
 
 if Code.ensure_loaded?(GenStage) do
   defmodule Verk.EventHandler do
+    @moduledoc """
+    A GenStage producer that broadcasts events to subscribed consumers.
+    """
     use GenStage
 
     def start_link do

--- a/lib/verk/supervisor.ex
+++ b/lib/verk/supervisor.ex
@@ -27,7 +27,8 @@ defmodule Verk.Supervisor do
     queue_stats_watcher = worker(Watcher, [Verk.EventManager, Verk.QueueStats, []])
     redis               = worker(Redix, [redis_url, [name: Verk.Redis]])
 
-    children = [redis, verk_event_manager, queue_stats_watcher, schedule_manager] ++ children
+    children = [redis, verk_event_manager, queue_stats_watcher, schedule_manager]
+               |> Kernel.++(children)
                |> add_gen_stage_event_handler()
     supervise(children, strategy: :one_for_one)
   end

--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -221,6 +221,10 @@ defmodule Verk.WorkersManager do
   end
 
   defp notify!(event) do
+    if Application.get_env(:verk, :use_gen_stage, false) && Code.ensure_loaded?(GenStage) do
+      Verk.EventHandler.async_notify(event)
+    end
+
     :ok = GenEvent.ack_notify(Verk.EventManager, event)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule Verk.Mixfile do
      { :poison, "~> 2.0"},
      { :poolboy, "~> 1.5.1" },
      { :watcher, "~> 1.0" },
+     { :gen_stage, "== 0.11.0", optional: true },
      { :credo, "~> 0.4", only: [:dev, :test] },
      { :earmark, "~> 1.0", only: :dev },
      { :ex_doc, "~> 0.13", only: :dev },

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,7 @@
   "credo": {:hex, :credo, "0.4.11", "03a64e9d53309b7132556284dda0be57ba1013885725124cfea7748d740c6170", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "gen_stage": {:hex, :gen_stage, "0.11.0", "943bdfa85c75fa624e0a36a9d135baad20a523be040178f5a215444b45c66ea4", [:mix], []},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.9.1", "6c2b4eaf2588a6f3ef29663d28c992531ca3f0bc832a97e0359bc822978e1c5d", [:mix], [{:hackney, "~> 1.6.0", [hex: :hackney, optional: false]}]},


### PR DESCRIPTION
Attempts to close #100

Disclaimer: I'm not super familiar with GenStage architecture 🙂 

I wasn't super sure how to handle the configuration/organization of an optional dependency, but this PR implements a `GenStage.BroadcastDispatcher`that allows implementing a GenStage consumer for Verk events.  It would also potentially be possible to allow users to define their own module for the producer as well, but I didn't write anything to support that.

I didn't add any docs either, but setup would look something like:

```elixir
# module to consume GenStage events
defmodule Printer do
  use GenStage

  def start_link() do
    GenStage.start_link(__MODULE__, :ok)
  end

  def init(:ok) do
    {:consumer, :ok, subscribe_to: [Verk.EventHandler]}
  end

  def handle_events(events, _from, state) do
    Enum.each(events, fn(event) ->
      # event might be any of Verk.JobFinished, Verk.JobStarted, or Verk.JobFailed
      IO.inspect event
    end)

    {:noreply, [], state}
  end
end

# supervision tree
children = [
  # order is important in this case
  supervisor(Verk.Supervisor, []),
  worker(Printer, [])
]
```

