### PR TITLE
fix compile warnings for Elixir 1.4

### DIFF
--- a/lib/verk.ex
+++ b/lib/verk.ex
@@ -49,7 +49,7 @@ defmodule Verk do
     enqueue(job, redis)
   end
   def enqueue(job = %Job{max_retry_count: count}, _redis) when not is_integer(count), do: {:error, {:invalid_max_retry_count, job}}
-  def enqueue(job = %Job{jid: nil}, redis), do: enqueue(%Job{job | jid: generate_jid}, redis)
+  def enqueue(job = %Job{jid: nil}, redis), do: enqueue(%Job{job | jid: generate_jid()}, redis)
   def enqueue(%Job{jid: jid, queue: queue} = job, redis) do
     case Redix.command(redis, ["LPUSH", "queue:#{queue}", Poison.encode!(job)]) do
       {:ok, _} -> {:ok, jid}
@@ -74,7 +74,7 @@ defmodule Verk do
   def schedule(job = %Job{class: nil}, %DateTime{}, _redis), do: {:error, {:missing_module, job}}
   def schedule(job = %Job{args: args}, %DateTime{}, _redis) when not is_list(args), do: {:error, {:missing_args, job}}
   def schedule(job = %Job{jid: nil}, perform_at = %DateTime{}, redis) do
-    schedule(%Job{job | jid: generate_jid}, perform_at, redis)
+    schedule(%Job{job | jid: generate_jid()}, perform_at, redis)
   end
   def schedule(%Job{jid: jid} = job, %DateTime{} = perform_at, redis) do
     if Time.after?(Time.now, perform_at) do

--- a/lib/verk/queue_manager.ex
+++ b/lib/verk/queue_manager.ex
@@ -7,7 +7,6 @@ defmodule Verk.QueueManager do
   require Logger
   alias Verk.{DeadSet, RetrySet, Time, Job}
 
-  @processing_key "processing"
   @default_stacktrace_size 5
 
   @external_resource "priv/lpop_rpush_src_dest.lua"

--- a/lib/verk/queue_stats.ex
+++ b/lib/verk/queue_stats.ex
@@ -35,7 +35,7 @@ defmodule Verk.QueueStats do
   @doc false
   def init(_) do
     QueueStatsCounters.init
-    Process.send_after(self, :persist_stats, @persist_interval)
+    Process.send_after(self(), :persist_stats, @persist_interval)
     {:ok, nil}
   end
 
@@ -68,7 +68,7 @@ defmodule Verk.QueueStats do
       {:error, reason} ->
         Logger.error("QueueStats failed to persist stats to Redis. Reason: #{inspect reason}")
     end
-    Process.send_after(self, :persist_stats, @persist_interval)
+    Process.send_after(self(), :persist_stats, @persist_interval)
     {:ok, state}
   end
 

--- a/lib/verk/queue_stats_counters.ex
+++ b/lib/verk/queue_stats_counters.ex
@@ -65,7 +65,7 @@ defmodule Verk.QueueStatsCounters do
   """
   @spec persist :: :ok | {:error, term}
   def persist do
-    cmds = Enum.reduce(counters, [], fn {queue, _started, processed, failed, last_processed, last_failed}, commands ->
+    cmds = Enum.reduce(counters(), [], fn {queue, _started, processed, failed, last_processed, last_failed}, commands ->
       delta_processed = processed - last_processed
       delta_failed    = failed - last_failed
       :ets.update_counter(@counters_table, queue, [{5, delta_processed}, {6, delta_failed}])

--- a/lib/verk/schedule_manager.ex
+++ b/lib/verk/schedule_manager.ex
@@ -79,6 +79,6 @@ defmodule Verk.ScheduleManager do
     schedule_fetch!(fetch_message, interval)
   end
   defp schedule_fetch!(fetch_message, interval) do
-    Process.send_after(self, fetch_message, interval)
+    Process.send_after(self(), fetch_message, interval)
   end
 end

--- a/lib/verk/worker.ex
+++ b/lib/verk/worker.ex
@@ -34,10 +34,10 @@ defmodule Verk.Worker do
     try do
       :erlang.put(@process_dict_key, job)
       [job.class] |> Module.safe_concat |> apply(:perform, job.args)
-      GenServer.cast(manager, {:done, self, job.jid})
+      GenServer.cast(manager, {:done, self(), job.jid})
       {:stop, :normal, state}
     rescue
-      exception -> GenServer.cast(manager, {:failed, self, job.jid, exception, System.stacktrace})
+      exception -> GenServer.cast(manager, {:failed, self(), job.jid, exception, System.stacktrace})
       {:stop, :failed, state}
     end
   end

--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -82,7 +82,7 @@ defmodule Verk.WorkersManager do
 
     Logger.info "Workers Manager started for queue #{queue_name}"
 
-    send self, :enqueue_inprogress
+    send self(), :enqueue_inprogress
     Verk.QueueStats.reset_started(queue_name)
 
     {:ok, state}
@@ -198,7 +198,7 @@ defmodule Verk.WorkersManager do
       worker when is_pid(worker) ->
         monitor!(state.monitors, worker, job)
         Log.start(job, worker)
-        Verk.Worker.perform_async(worker, self, job)
+        Verk.Worker.perform_async(worker, self(), job)
         notify!(%Events.JobStarted{job: job, started_at: Time.now})
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -14,8 +14,8 @@ defmodule Verk.Mixfile do
      test_coverage: [tool: Coverex.Task, coveralls: true],
      name: "Verk",
      description: @description,
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
There are a couple Erlang 19 warnings as well, but I was less sure about changing them:

```
warning: crypto:rand_bytes/1 is deprecated and will be removed in a future release; use crypto:strong_rand_bytes/1
  lib/verk.ex:92

warning: random:uniform/1: the 'random' module is deprecated; use the 'rand' module instead
  lib/verk/retry_set.ex:38
```