### PR TITLE
Populated enqueued_at time during enqueue call

### DIFF
--- a/lib/verk.ex
+++ b/lib/verk.ex
@@ -51,6 +51,7 @@ defmodule Verk do
   def enqueue(job = %Job{max_retry_count: count}, _redis) when not is_integer(count), do: {:error, {:invalid_max_retry_count, job}}
   def enqueue(job = %Job{jid: nil}, redis), do: enqueue(%Job{job | jid: generate_jid()}, redis)
   def enqueue(%Job{jid: jid, queue: queue} = job, redis) do
+    job = %Job{job | enqueued_at: Time.now |> DateTime.to_unix}
     case Redix.command(redis, ["LPUSH", "queue:#{queue}", Poison.encode!(job)]) do
       {:ok, _} -> {:ok, jid}
       {:error, reason} -> {:error, reason}

--- a/test/verk_test.exs
+++ b/test/verk_test.exs
@@ -60,37 +60,46 @@ defmodule VerkTest do
     test "a job with a jid and a queue passing redis connection" do
       job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker",
         args: [], max_retry_count: 1 }
+      now = Time.now
+      expected_job = %Verk.Job{ job | enqueued_at: now |> DateTime.to_unix }
       encoded_job = "encoded_job"
-      expect(Poison, :encode!, [job], encoded_job)
+      expect(Time, :now, [], now)
+      expect(Poison, :encode!, [expected_job], encoded_job)
       expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })
 
       assert enqueue(job, Verk.Redis) == { :ok, "job_id" }
 
-      assert validate [Poison, Redix]
+      assert validate [Poison, Redix, Time]
     end
 
     test "a job with a jid and a queue passing no redis connection" do
       job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker",
         args: [], max_retry_count: 1 }
+      now = Time.now
+      expected_job = %Verk.Job{ job | enqueued_at: now |> DateTime.to_unix }
       encoded_job = "encoded_job"
-      expect(Poison, :encode!, [job], encoded_job)
+      expect(Time, :now, [], now)
+      expect(Poison, :encode!, [expected_job], encoded_job)
       expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })
 
       assert enqueue(job) == { :ok, "job_id" }
 
-      assert validate [Poison, Redix]
+      assert validate [Poison, Redix, Time]
     end
 
     test "a job with a jid and a queue" do
       job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker",
         args: [], max_retry_count: 1 }
+      now = Time.now
+      expected_job = %Verk.Job{ job | enqueued_at: now |> DateTime.to_unix }
       encoded_job = "encoded_job"
-      expect(Poison, :encode!, [job], encoded_job)
+      expect(Time, :now, [], now)
+      expect(Poison, :encode!, [expected_job], encoded_job)
       expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })
 
       assert enqueue(job) == { :ok, "job_id" }
 
-      assert validate [Poison, Redix]
+      assert validate [Poison, Redix, Time]
     end
 
     test "a job without a jid" do


### PR DESCRIPTION
Fixes #109, as long as I understood the ticket :D

Even when moving scheduled jobs we need to call `enqueue` so just populate the field in that method.