### PR TITLE
Use Confex to support env config at release runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,18 @@ config :verk, queues: [default: 25, priority: 10],
               redis_url: "redis://127.0.0.1:6379"
 ```
 
-The configuration for releases is still a work in progress.
+Verk supports the convention `{:system, "ENV_NAME", default}` for reading environment configuration at runtime using [Confex](https://hexdocs.pm/confex/readme.html):
+
+```elixir
+config :verk, queues: [default: 25, priority: 10],
+              max_retry_count: 10,
+              poll_interval: {:system, :integer, "VERK_POLL_INTERVAL", 5000},
+              start_job_log_level: :info,
+              done_job_log_level: :info,
+              fail_job_log_level: :info,
+              node_id: "1",
+              redis_url: {:system, "VERK_REDIS_URL", "redis://127.0.0.1:6379"}
+```
 
 ## Queues
 

--- a/lib/verk/dead_set.ex
+++ b/lib/verk/dead_set.ex
@@ -5,7 +5,7 @@ defmodule Verk.DeadSet do
   import Verk.Dsl
   alias Verk.{SortedSet, Job}
 
-  @max_dead_jobs Application.get_env(:verk, :max_dead_jobs, 100)
+  @max_dead_jobs Confex.get(:verk, :max_dead_jobs, 100)
   @timeout 60 * 60 * 24 * 7 # a week
 
   @dead_key "dead"

--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -3,7 +3,7 @@ defmodule Verk.Job do
   The Job struct
   """
 
-  @default_max_retry_count Application.get_env(:verk, :max_retry_count, 25)
+  @default_max_retry_count Confex.get(:verk, :max_retry_count, 25)
   @keys [error_message: nil, failed_at: nil, retry_count: 0, queue: nil, class: nil, args: [],
          jid: nil, finished_at: nil, enqueued_at: nil, retried_at: nil, error_backtrace: nil,
          max_retry_count: @default_max_retry_count]

--- a/lib/verk/log.ex
+++ b/lib/verk/log.ex
@@ -9,19 +9,19 @@ defmodule Verk.Log do
 
   def start(%Job{jid: job_id, class: module}, process_id) do
     :verk
-    |> Application.get_env(:start_job_log_level, :info)
+    |> Confex.get(:start_job_log_level, :info)
     |> log("#{module} #{job_id} start", process_id: inspect(process_id))
   end
 
   def done(%Job{jid: job_id, class: module}, start_time, process_id) do
     :verk
-    |> Application.get_env(:done_job_log_level, :info)
+    |> Confex.get(:done_job_log_level, :info)
     |> log("#{module} #{job_id} done: #{elapsed_time(start_time)}", process_id: inspect(process_id))
   end
 
   def fail(%Job{jid: job_id, class: module}, start_time, process_id) do
     :verk
-    |> Application.get_env(:fail_job_log_level, :info)
+    |> Confex.get(:fail_job_log_level, :info)
     |> log("#{module} #{job_id} fail: #{elapsed_time(start_time)}", process_id: inspect(process_id))
   end
 

--- a/lib/verk/queue_manager.ex
+++ b/lib/verk/queue_manager.ex
@@ -83,9 +83,8 @@ defmodule Verk.QueueManager do
   Connect to redis
   """
   def init([queue_name]) do
-    node_id = Application.get_env(:verk, :node_id, "1")
-    {:ok, redis_url} = Application.fetch_env(:verk, :redis_url)
-    {:ok, redis} = Redix.start_link(redis_url)
+    node_id = Confex.get(:verk, :node_id, "1")
+    {:ok, redis} = Redix.start_link(Confex.get(:verk, :redis_url))
     Verk.Scripts.load(redis)
 
     state = %State{queue_name: queue_name, redis: redis, node_id: node_id}
@@ -178,7 +177,7 @@ defmodule Verk.QueueManager do
   end
 
   defp format_stacktrace(stacktrace) when is_list(stacktrace) do
-    stacktrace_limit = Application.get_env(:verk, :failed_job_stacktrace_size, @default_stacktrace_size)
+    stacktrace_limit = Confex.get(:verk, :failed_job_stacktrace_size, @default_stacktrace_size)
     Exception.format_stacktrace(Enum.slice(stacktrace, 0..(stacktrace_limit - 1)))
   end
 

--- a/lib/verk/schedule_manager.ex
+++ b/lib/verk/schedule_manager.ex
@@ -29,8 +29,7 @@ defmodule Verk.ScheduleManager do
   Connect to redis and timeout with the `poll_interval`
   """
   def init(_) do
-    {:ok, redis_url} = Application.fetch_env(:verk, :redis_url)
-    {:ok, redis} = Redix.start_link(redis_url)
+    {:ok, redis} = Redix.start_link(Confex.get(:verk, :redis_url))
     Verk.Scripts.load(redis)
 
     state = %State{redis: redis}
@@ -75,7 +74,7 @@ defmodule Verk.ScheduleManager do
   end
 
   defp schedule_fetch!(fetch_message) do
-    interval = Application.get_env(:verk, :poll_interval, @default_poll_interval)
+    interval = Confex.get(:verk, :poll_interval, @default_poll_interval)
     schedule_fetch!(fetch_message, interval)
   end
   defp schedule_fetch!(fetch_message, interval) do

--- a/lib/verk/supervisor.ex
+++ b/lib/verk/supervisor.ex
@@ -16,7 +16,7 @@ defmodule Verk.Supervisor do
 
   @doc false
   def init(_) do
-    queues = Confex.get(:verk, :queues, [])
+    queues = Confex.get_map(:verk, :queues, [])
     children = for {queue, size} <- queues, do: queue_child(queue, size)
 
     redis_url = Confex.get(:verk, :redis_url)

--- a/lib/verk/supervisor.ex
+++ b/lib/verk/supervisor.ex
@@ -16,10 +16,10 @@ defmodule Verk.Supervisor do
 
   @doc false
   def init(_) do
-    queues = Application.get_env(:verk, :queues, [])
+    queues = Confex.get(:verk, :queues, [])
     children = for {queue, size} <- queues, do: queue_child(queue, size)
 
-    {:ok, redis_url} = Application.fetch_env(:verk, :redis_url)
+    redis_url = Confex.get(:verk, :redis_url)
 
     schedule_manager    = worker(Verk.ScheduleManager, [], id: :schedule_manager)
     verk_event_manager  = worker(GenEvent, [[name: Verk.EventManager]])
@@ -56,7 +56,7 @@ defmodule Verk.Supervisor do
   end
 
   defp add_gen_stage_event_handler(children) do
-    if Application.get_env(:verk, :use_gen_stage, false) && Code.ensure_loaded?(GenStage) do
+    if Confex.get(:verk, :use_gen_stage, false) && Code.ensure_loaded?(GenStage) do
       [worker(Verk.EventProducer, []) | children]
     else
       children

--- a/lib/verk/workers_manager.ex
+++ b/lib/verk/workers_manager.ex
@@ -72,7 +72,7 @@ defmodule Verk.WorkersManager do
   """
   def init([workers_manager_name, queue_name, queue_manager_name, pool_name, size]) do
     monitors = :ets.new(workers_manager_name, [:named_table, read_concurrency: true])
-    timeout = Application.get_env(:verk, :workers_manager_timeout, @default_timeout)
+    timeout = Confex.get(:verk, :workers_manager_timeout, @default_timeout)
     state = %State{queue_name: queue_name,
                   queue_manager_name: queue_manager_name,
                   pool_name: pool_name,
@@ -226,7 +226,7 @@ defmodule Verk.WorkersManager do
   end
 
   defp notify!(event) do
-    if Application.get_env(:verk, :use_gen_stage, false) && Code.ensure_loaded?(GenStage) do
+    if Confex.get(:verk, :use_gen_stage, false) && Code.ensure_loaded?(GenStage) do
       Verk.EventProducer.async_notify(event)
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Verk.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :poison, :redix, :poolboy, :watcher],
+    [applications: [:logger, :confex, :poison, :redix, :poolboy, :watcher],
      env: [node_id: "1", redis_url: "redis://127.0.0.1:6379"]]
   end
 
@@ -28,6 +28,7 @@ defmodule Verk.Mixfile do
      { :poison, "~> 2.0"},
      { :poolboy, "~> 1.5.1" },
      { :watcher, "~> 1.0" },
+     { :confex, "~> 1.5.0" },
      { :gen_stage, "== 0.11.0", optional: true },
      { :credo, "~> 0.4", only: [:dev, :test] },
      { :earmark, "~> 1.0", only: :dev },

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "combine": {:hex, :combine, "0.9.2", "cd3c8721f378ebe032487d8a4fa2ced3181a456a3c21b16464da8c46904bb552", [:mix], []},
+  "confex": {:hex, :confex, "1.5.0", "172e4769d7a951aae3f9fd1b139da9ab0cd6a4d30b29959b0bde57826a19eb21", [:mix], []},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "coverex": {:hex, :coverex, "1.4.10", "f6b68f95b3d51d04571a09dd2071c980e8398a38cf663db22b903ecad1083d51", [:mix], [{:httpoison, "~> 0.9", [hex: :httpoison, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
   "credo": {:hex, :credo, "0.4.11", "03a64e9d53309b7132556284dda0be57ba1013885725124cfea7748d740c6170", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},

--- a/test/dead_set_test.exs
+++ b/test/dead_set_test.exs
@@ -5,7 +5,7 @@ defmodule Verk.DeadSetTest do
   import :meck
 
   setup do
-    { :ok, redis } = Application.fetch_env!(:verk, :redis_url) |> Redix.start_link
+    { :ok, redis } = Confex.get(:verk, :redis_url) |> Redix.start_link
     Redix.command!(redis, ~w(DEL dead))
     on_exit fn -> unload end
     { :ok, %{ redis: redis } }

--- a/test/queue_manager_test.exs
+++ b/test/queue_manager_test.exs
@@ -20,8 +20,8 @@ defmodule Verk.QueueManagerTest do
 
   describe "init/1" do
     test "sets up redis connection" do
-      { :ok, redis_url } = Application.fetch_env(:verk, :redis_url)
-      node_id = Application.get_env(:verk, :node_id, "1")
+      redis_url = Confex.get(:verk, :redis_url)
+      node_id = Confex.get(:verk, :node_id, "1")
 
       expect(Redix, :start_link, [redis_url], {:ok, :redis })
       expect(Verk.Scripts, :load, [:redis], :ok)

--- a/test/queue_stats_test.exs
+++ b/test/queue_stats_test.exs
@@ -5,8 +5,7 @@ defmodule Verk.QueueStatsTest do
   @table :queue_stats
 
   setup do
-    { :ok, _ } = Application.fetch_env(:verk, :redis_url)
-                  |> elem(1)
+    { :ok, _ } = Confex.get(:verk, :redis_url)
                   |> Redix.start_link([name: Verk.Redis])
     Redix.pipeline!(Verk.Redis, [["DEL",
         "stat:failed", "stat:processed",

--- a/test/queue_test.exs
+++ b/test/queue_test.exs
@@ -6,8 +6,7 @@ defmodule Verk.QueueTest do
   @queue_key "queue:default"
 
   setup do
-    { :ok, pid } = Application.fetch_env(:verk, :redis_url)
-                    |> elem(1)
+    { :ok, pid } = Confex.get(:verk, :redis_url)
                     |> Redix.start_link([name: Verk.Redis])
     Redix.command!(pid, ~w(DEL #{@queue_key}))
     on_exit fn ->

--- a/test/redis_scripts_test.exs
+++ b/test/redis_scripts_test.exs
@@ -7,8 +7,7 @@ defmodule RedisScriptsTest do
   @requeue_job_now_script File.read!("#{:code.priv_dir(:verk)}/requeue_job_now.lua")
 
   setup do
-    { :ok, redis } = Application.fetch_env(:verk, :redis_url)
-                      |> elem(1)
+    { :ok, redis } = Confex.get(:verk, :redis_url)
                       |> Redix.start_link([name: Verk.Redis])
     on_exit fn -> Redix.stop(redis) end
     { :ok, %{ redis: redis } }

--- a/test/schedule_manager_test.exs
+++ b/test/schedule_manager_test.exs
@@ -14,7 +14,7 @@ defmodule Verk.ScheduleManagerTest do
   test "init load scripts and schedule fetch" do
     state = %State{ redis: :redis }
 
-    { :ok, redis_url } = Application.fetch_env(:verk, :redis_url)
+    redis_url = Confex.get(:verk, :redis_url)
 
     expect(Redix, :start_link, [redis_url], {:ok, :redis })
     expect(Verk.Scripts, :load, [:redis], :ok)

--- a/test/sorted_set_test.exs
+++ b/test/sorted_set_test.exs
@@ -7,7 +7,7 @@ defmodule Verk.SortedSetTest do
 
   setup do
     on_exit fn -> unload end
-    { :ok, redis } = Application.fetch_env!(:verk, :redis_url) |> Redix.start_link
+    { :ok, redis } = Confex.get(:verk, :redis_url) |> Redix.start_link
     Redix.command!(redis, ~w(DEL sorted))
     { :ok, %{ redis: redis } }
   end

--- a/test/stats_test.exs
+++ b/test/stats_test.exs
@@ -3,9 +3,8 @@ defmodule Verk.StatsTest do
   import Verk.Stats
 
   setup do
-    { :ok, redis } = Application.fetch_env(:verk, :redis_url)
-                       |> elem(1)
-                       |> Redix.start_link
+    { :ok, redis } = Confex.get(:verk, :redis_url)
+                      |> Redix.start_link
     Redix.command!(redis, ~w(DEL stat:processed stat:failed))
     Redix.command!(redis, ~w(DEL stat:processed:default stat:failed:default))
     { :ok, redis: redis }

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -124,7 +124,7 @@ defmodule Verk.WorkersManagerTest do
       queue_manager_name = "queue_manager_name"
       pool_name = "pool_name"
       pool_size = "size"
-      timeout = Application.get_env(:verk, :workers_manager_timeout)
+      timeout = Confex.get(:verk, :workers_manager_timeout)
       state = %State{ queue_name: queue_name, queue_manager_name: queue_manager_name,
                       pool_name: pool_name, pool_size: pool_size,
                       monitors: :workers_manager, timeout: timeout }


### PR DESCRIPTION
Add supports for env config at release runtime using Confex.

I did not bother emulating fetch and fetch! for `redis_url` as I dont think this adds much more safety, it will simply error differently . We could probably add one check (in the supervisor ?) that would raise if `redis_url` is not defined.