### PR TITLE
Add result of job to Events.JobFinished

### DIFF
--- a/lib/verk/events.ex
+++ b/lib/verk/events.ex
@@ -1,7 +1,7 @@
 defmodule Verk.Events do
   defmodule JobFinished do
     @moduledoc false
-    defstruct [:job, :finished_at]
+    defstruct [:job, :result, :finished_at]
   end
 
   defmodule JobStarted do

--- a/lib/verk/worker.ex
+++ b/lib/verk/worker.ex
@@ -33,8 +33,8 @@ defmodule Verk.Worker do
   def handle_cast({:perform, job, manager}, state) do
     try do
       :erlang.put(@process_dict_key, job)
-      [job.class] |> Module.safe_concat |> apply(:perform, job.args)
-      GenServer.cast(manager, {:done, self(), job.jid})
+      result = [job.class] |> Module.safe_concat |> apply(:perform, job.args)
+      GenServer.cast(manager, {:done, self(), job.jid, result})
       {:stop, :normal, state}
     rescue
       exception -> GenServer.cast(manager, {:failed, self(), job.jid, exception, System.stacktrace})

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -27,7 +27,7 @@ defmodule Verk.WorkerTest do
       assert handle_cast({ :perform, job, worker }, :state) == { :stop, :normal, :state }
 
       assert_receive :perform_executed
-      assert_receive {:"$gen_cast", {:done, ^worker, "job_id"}}
+      assert_receive {:"$gen_cast", {:done, ^worker, "job_id", _}}
     end
 
     test "cast perform runs the specified atom module with the args succeding" do
@@ -36,7 +36,7 @@ defmodule Verk.WorkerTest do
       assert handle_cast({ :perform, job, worker }, :state) == { :stop, :normal, :state }
 
       assert_receive :perform_executed
-      assert_receive {:"$gen_cast", {:done, ^worker, "job_id"}}
+      assert_receive {:"$gen_cast", {:done, ^worker, "job_id", _}}
     end
 
     test "cast perform runs the no exist module with the args succeding" do
@@ -63,7 +63,7 @@ defmodule Verk.WorkerTest do
       assert handle_cast({ :perform, job, worker }, :state) == { :stop, :normal, :state }
 
       assert_receive ^job
-      assert_receive {:"$gen_cast", {:done, ^worker, "job_id"}}
+      assert_receive {:"$gen_cast", {:done, ^worker, "job_id", _}}
     end
   end
 

--- a/test/workers_manager_test.exs
+++ b/test/workers_manager_test.exs
@@ -291,7 +291,7 @@ defmodule Verk.WorkersManagerTest do
       assert handle_info({ :DOWN, ref, :_, worker, :normal }, state) == { :noreply, state, 0 }
 
       assert :ets.lookup(state.monitors, worker) == []
-      assert_receive %Verk.Events.JobFinished{ job: ^job, finished_at: _ }
+      assert_receive %Verk.Events.JobFinished{ job: ^job, result: _, finished_at: _ }
 
       assert validate [Verk.QueueManager, :poolboy]
     end
@@ -338,10 +338,10 @@ defmodule Verk.WorkersManagerTest do
       expect(:poolboy, :checkin, [pool_name, worker], :ok)
 
       :ets.insert(monitors, { worker, job_id, job, make_ref, Time.now })
-      assert handle_cast({ :done, worker, job_id }, state) == { :noreply, state, 0 }
+      assert handle_cast({ :done, worker, job_id, :ok }, state) == { :noreply, state, 0 }
 
       assert :ets.lookup(state.monitors, worker) == []
-      assert_receive %Verk.Events.JobFinished{ job: ^job, finished_at: _ }
+      assert_receive %Verk.Events.JobFinished{ job: ^job, result: _, finished_at: _ }
 
       assert validate [:poolboy, Verk.QueueManager]
     end


### PR DESCRIPTION
In my task, I had to do postprocessing after doing the work in `Verk.Events.JobFinished`
Maybe it will be useful ...