### PR TITLE
Handle Poison 3.X decode error tuples

### DIFF
--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -22,6 +22,7 @@ defmodule Verk.Job do
     case Poison.decode(payload, as: %__MODULE__{}) do
       {:ok, job} -> {:ok, %Verk.Job{job | original_json: payload}}
       {:error, error} -> {:error, error}
+      {:error, :invalid, pos} -> {:error, "Invalid json at position: #{pos}"}
     end
   end
 


### PR DESCRIPTION
Poison 3.0.0 introduces a change to the return tuple that breaks the handling added in #91. The method signature change is documented in: devinus/poison#149. It seems that this signature might be changed back in Poison 4.0.0.

This change allows Verk to support Poison 3.0.0 and not crash on invalid jobs.

See https://github.com/edgurgel/verk/issues/144