### PR TITLE
Change RetrySet to calculate next retry safely

### DIFF
--- a/lib/verk/retry_set.ex
+++ b/lib/verk/retry_set.ex
@@ -41,6 +41,8 @@ defmodule Verk.RetrySet do
     else
       default_calculate_retry_at(failed_at, retry_count)
     end
+    rescue
+      ArgumentError -> default_calculate_retry_at(failed_at, retry_count)
   end
 
   defp default_calculate_retry_at(failed_at, retry_count) do

--- a/test/retry_set_test.exs
+++ b/test/retry_set_test.exs
@@ -41,6 +41,18 @@ defmodule Verk.RetrySetTest do
 
       assert validate [Poison, Redix]
     end
+
+    test "custom retry_at but module doesn't exist" do
+      job = %Verk.Job{ class: "Verk.NoModule", retry_count: 1 }
+      failed_at = 1
+      retry_at  = "29.0"
+      expect(Poison, :encode!, [job], :payload)
+      expect(Redix, :command, [:redis, ["ZADD", "retry", retry_at, :payload]], { :ok, 1 })
+
+      assert add(job, failed_at, :redis) == :ok
+
+      assert validate [Poison, Redix]
+    end
   end
 
   describe "add!/3" do


### PR DESCRIPTION
It will rescue if the Worker module name does not exist

It fixes #151 