### PR TITLE
Fix #149 - Replace map with array for job with no args.

### DIFF
--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -20,7 +20,7 @@ defmodule Verk.Job do
   @spec decode(binary) :: {:ok, %__MODULE__{}} | {:error, Poison.Error.t}
   def decode(payload) do
     case Poison.decode(payload, as: %__MODULE__{}) do
-      {:ok, job} -> {:ok, %Verk.Job{job | original_json: payload}}
+      {:ok, job} -> {:ok, build(job, payload)}
       {:error, error} -> {:error, error}
       {:error, :invalid, pos} -> {:error, "Invalid json at position: #{pos}"}
     end
@@ -32,10 +32,18 @@ defmodule Verk.Job do
   @spec decode!(binary) :: %__MODULE__{}
   def decode!(payload) do
     job = Poison.decode!(payload, as: %__MODULE__{})
-    %Verk.Job{job | original_json: payload}
+    build(job, payload)
   end
 
   def default_max_retry_count do
     @default_max_retry_count
+  end
+
+  defp build(job = %{args: %{}}, payload) do
+    build(%{job | args: []}, payload)
+  end
+
+  defp build(job, payload) do
+    %Verk.Job{job | original_json: payload}
   end
 end

--- a/test/job_test.exs
+++ b/test/job_test.exs
@@ -9,6 +9,13 @@ defmodule Verk.JobTest do
 
       assert Job.decode!(payload) == %Job{ queue: "test_queue", args: [1, 2, 3], original_json: payload, max_retry_count: 5}
     end
+
+    test "replaces map with array when job has no args" do
+      payload = ~s({ "queue" : "test_queue", "args" : {},
+                   "max_retry_count" : 5})
+
+      assert Job.decode!(payload) == %Job{ queue: "test_queue", args: [], original_json: payload, max_retry_count: 5}
+    end
   end
 
   describe "decode/1" do
@@ -24,6 +31,13 @@ defmodule Verk.JobTest do
                    "max_retry_count" : 5})
 
       assert {:error, _} = Job.decode(payload)
+    end
+
+    test "replaces map with array when job has no args" do
+      payload = ~s({ "queue" : "test_queue", "args" : {},
+                   "max_retry_count" : 5})
+
+      assert Job.decode(payload) == {:ok, %Job{ queue: "test_queue", args: [], original_json: payload, max_retry_count: 5}}
     end
   end
 end


### PR DESCRIPTION
When decoding payload to create a job replace empty map for args with
empty array.