### PR TITLE
Resilient Verk - Fix scaling up and down

### DIFF
--- a/lib/verk/in_progress_queue.ex
+++ b/lib/verk/in_progress_queue.ex
@@ -9,7 +9,15 @@ defmodule Verk.InProgressQueue do
 
   def enqueue_in_progress(queue_name, node_id, redis) do
     in_progress_key = inprogress(queue_name, node_id)
-    Redix.command(redis, ["EVALSHA", @lpop_rpush_src_dest_script_sha, 2, in_progress_key, "queue:#{queue_name}", @max_enqueue_inprogress])
+
+    Redix.command(redis, [
+      "EVALSHA",
+      @lpop_rpush_src_dest_script_sha,
+      2,
+      in_progress_key,
+      "queue:#{queue_name}",
+      @max_enqueue_inprogress
+    ])
   end
 
   defp inprogress(queue_name, node_id) do

--- a/lib/verk/in_progress_queue.ex
+++ b/lib/verk/in_progress_queue.ex
@@ -1,0 +1,18 @@
+defmodule Verk.InProgressQueue do
+  @moduledoc """
+  This module interacts with the in progress queue
+  """
+
+  @external_resource "priv/lpop_rpush_src_dest.lua"
+  @lpop_rpush_src_dest_script_sha Verk.Scripts.sha("lpop_rpush_src_dest")
+  @max_enqueue_inprogress 1000
+
+  def enqueue_in_progress(queue_name, node_id, redis) do
+    in_progress_key = inprogress(queue_name, node_id)
+    Redix.command(redis, ["EVALSHA", @lpop_rpush_src_dest_script_sha, 2, in_progress_key, "queue:#{queue_name}", @max_enqueue_inprogress])
+  end
+
+  defp inprogress(queue_name, node_id) do
+    "inprogress:#{queue_name}:#{node_id}"
+  end
+end

--- a/lib/verk/log.ex
+++ b/lib/verk/log.ex
@@ -16,7 +16,8 @@ defmodule Verk.Log do
   def done(%Job{jid: job_id, class: module}, start_time, process_id) do
     :verk
     |> Confex.get_env(:done_job_log_level, :info)
-    |> log("#{module} #{job_id} done: #{elapsed_time(start_time)}",
+    |> log(
+      "#{module} #{job_id} done: #{elapsed_time(start_time)}",
       process_id: inspect(process_id)
     )
   end
@@ -24,7 +25,8 @@ defmodule Verk.Log do
   def fail(%Job{jid: job_id, class: module}, start_time, process_id) do
     :verk
     |> Confex.get_env(:fail_job_log_level, :info)
-    |> log("#{module} #{job_id} fail: #{elapsed_time(start_time)}",
+    |> log(
+      "#{module} #{job_id} fail: #{elapsed_time(start_time)}",
       process_id: inspect(process_id)
     )
   end

--- a/lib/verk/node.ex
+++ b/lib/verk/node.ex
@@ -5,24 +5,31 @@ defmodule Verk.Node do
 
   @verk_nodes_key "verk_nodes"
 
-  @spec register(String.t, non_neg_integer, GenServer.t) :: :ok | {:error, :verk_node_id_already_running}
+  @spec register(String.t(), non_neg_integer, GenServer.t()) ::
+          :ok | {:error, :verk_node_id_already_running}
   def register(verk_node_id, ttl, redis) do
-    case Redix.pipeline!(redis, [["SADD", @verk_nodes_key, verk_node_id],
-                                 ["PSETEX", "verk:node:#{verk_node_id}", ttl, "alive"]]) do
+    case Redix.pipeline!(redis, [
+           ["SADD", @verk_nodes_key, verk_node_id],
+           ["PSETEX", "verk:node:#{verk_node_id}", ttl, "alive"]
+         ]) do
       [1, _] -> :ok
       _ -> {:error, :node_id_already_running}
     end
   end
 
-  @spec deregister!(String.t, GenServer.t) :: :ok
+  @spec deregister!(String.t(), GenServer.t()) :: :ok
   def deregister!(verk_node_id, redis) do
-    Redix.pipeline!(redis, [["DEL", verk_node_key(verk_node_id)],
-                            ["DEL", verk_node_queues_key(verk_node_id)],
-                            ["SREM", @verk_nodes_key, verk_node_id]])
+    Redix.pipeline!(redis, [
+      ["DEL", verk_node_key(verk_node_id)],
+      ["DEL", verk_node_queues_key(verk_node_id)],
+      ["SREM", @verk_nodes_key, verk_node_id]
+    ])
+
     :ok
   end
 
-  @spec members(integer, non_neg_integer, GenServer.t) :: {:ok, [String.t]} | {:more, [String.t], integer}
+  @spec members(integer, non_neg_integer, GenServer.t()) ::
+          {:ok, [String.t()]} | {:more, [String.t()], integer}
   def members(cursor \\ 0, count \\ 25, redis) do
     case Redix.command!(redis, ["SSCAN", @verk_nodes_key, cursor, "COUNT", count]) do
       ["0", verk_nodes] -> {:ok, verk_nodes}
@@ -30,19 +37,26 @@ defmodule Verk.Node do
     end
   end
 
-  @spec ttl!(String.t, GenServer.t) :: integer
+  @spec ttl!(String.t(), GenServer.t()) :: integer
   def ttl!(verk_node_id, redis) do
     Redix.command!(redis, ["PTTL", verk_node_key(verk_node_id)])
   end
 
-  @spec expire_in!(String.t, integer, GenServer.t) :: integer
+  @spec expire_in!(String.t(), integer, GenServer.t()) :: integer
   def expire_in!(verk_node_id, ttl, redis) do
     Redix.command!(redis, ["PSETEX", verk_node_key(verk_node_id), ttl, "alive"])
   end
 
-  @spec queues!(String.t, integer, non_neg_integer, GenServer.t) :: {:ok, [String.t]} | {:more, [String.t], integer}
+  @spec queues!(String.t(), integer, non_neg_integer, GenServer.t()) ::
+          {:ok, [String.t()]} | {:more, [String.t()], integer}
   def queues!(verk_node_id, cursor \\ 0, count \\ 25, redis) do
-    case Redix.command!(redis, ["SSCAN", verk_node_queues_key(verk_node_id), cursor, "COUNT", count]) do
+    case Redix.command!(redis, [
+           "SSCAN",
+           verk_node_queues_key(verk_node_id),
+           cursor,
+           "COUNT",
+           count
+         ]) do
       ["0", queues] -> {:ok, queues}
       [cursor, queues] -> {:more, queues, cursor}
     end

--- a/lib/verk/node.ex
+++ b/lib/verk/node.ex
@@ -1,0 +1,61 @@
+defmodule Verk.Node do
+  @moduledoc """
+  Node data controller
+  """
+
+  @verk_nodes_key "verk_nodes"
+
+  @spec register(String.t, non_neg_integer, GenServer.t) :: :ok | {:error, :verk_node_id_already_running}
+  def register(verk_node_id, ttl, redis) do
+    case Redix.pipeline!(redis, [["SADD", @verk_nodes_key, verk_node_id],
+                                 ["PSETEX", "verk:node:#{verk_node_id}", ttl, "alive"]]) do
+      [1, _] -> :ok
+      _ -> {:error, :node_id_already_running}
+    end
+  end
+
+  @spec deregister!(String.t, GenServer.t) :: :ok
+  def deregister!(verk_node_id, redis) do
+    Redix.pipeline!(redis, [["DEL", verk_node_key(verk_node_id)],
+                            ["DEL", verk_node_queues_key(verk_node_id)],
+                            ["SREM", @verk_nodes_key, verk_node_id]])
+    :ok
+  end
+
+  @spec members(integer, non_neg_integer, GenServer.t) :: {:ok, [String.t]} | {:more, [String.t], integer}
+  def members(cursor \\ 0, count \\ 25, redis) do
+    case Redix.command!(redis, ["SSCAN", @verk_nodes_key, cursor, "COUNT", count]) do
+      ["0", verk_nodes] -> {:ok, verk_nodes}
+      [cursor, verk_nodes] -> {:more, verk_nodes, cursor}
+    end
+  end
+
+  @spec ttl!(String.t, GenServer.t) :: integer
+  def ttl!(verk_node_id, redis) do
+    Redix.command!(redis, ["PTTL", verk_node_key(verk_node_id)])
+  end
+
+  @spec expire_in!(String.t, integer, GenServer.t) :: integer
+  def expire_in!(verk_node_id, ttl, redis) do
+    Redix.command!(redis, ["PSETEX", verk_node_key(verk_node_id), ttl, "alive"])
+  end
+
+  @spec queues!(String.t, integer, non_neg_integer, GenServer.t) :: {:ok, [String.t]} | {:more, [String.t], integer}
+  def queues!(verk_node_id, cursor \\ 0, count \\ 25, redis) do
+    case Redix.command!(redis, ["SSCAN", verk_node_queues_key(verk_node_id), cursor, "COUNT", count]) do
+      ["0", queues] -> {:ok, queues}
+      [cursor, queues] -> {:more, queues, cursor}
+    end
+  end
+
+  def add_queue!(verk_node_id, queue, redis) do
+    Redix.command!(redis, ["SADD", verk_node_queues_key(verk_node_id), queue])
+  end
+
+  def remove_queue!(verk_node_id, queue, redis) do
+    Redix.command!(redis, ["SREM", verk_node_queues_key(verk_node_id), queue])
+  end
+
+  defp verk_node_key(verk_node_id), do: "verk:node:#{verk_node_id}"
+  defp verk_node_queues_key(verk_node_id), do: "verk:node:#{verk_node_id}:queues"
+end

--- a/lib/verk/node/manager.ex
+++ b/lib/verk/node/manager.ex
@@ -1,0 +1,91 @@
+defmodule Verk.Node.Manager do
+  @moduledoc """
+  NodeManager keeps track of the nodes that are working on the queues
+  """
+
+  use GenServer
+  require Logger
+  alias Verk.InProgressQueue
+
+  @doc false
+  def start_link, do: GenServer.start_link(__MODULE__, [], name: __MODULE__)
+
+  @doc false
+  def init(_) do
+    local_verk_node_id = Application.fetch_env!(:verk, :local_node_id)
+    frequency          = Confex.get_env(:verk, :heartbeat, 30_000)
+
+    Logger.info "Node Manager started for node #{local_verk_node_id}. Heartbeat will run every #{frequency} milliseconds"
+
+    :ok = Verk.Node.register(local_verk_node_id, 2 * frequency, Verk.Redis)
+    Process.send_after(self(), :heartbeat, frequency)
+    {:ok, {local_verk_node_id, frequency}}
+  end
+
+  @doc false
+  def handle_info(:heartbeat, state = {local_verk_node_id, frequency}) do
+    faulty_nodes = find_faulty_nodes(local_verk_node_id)
+
+    for verk_node_id <- faulty_nodes do
+      Logger.warn "Verk Node #{verk_node_id} seems to be down. Restoring jobs!"
+
+      cleanup_queues(verk_node_id)
+
+      Verk.Node.deregister!(verk_node_id, Verk.Redis)
+    end
+
+    heartbeat!(local_verk_node_id, frequency)
+    {:noreply, state}
+  end
+
+  defp cleanup_queues(verk_node_id, cursor \\ 0) do
+    case Verk.Node.queues!(verk_node_id, cursor, Verk.Redis) do
+      {:ok, queues} ->
+        do_cleanup_queues(queues, verk_node_id)
+      {:more, queues, cursor} ->
+        do_cleanup_queues(queues, verk_node_id)
+        cleanup_queues(verk_node_id, cursor)
+    end
+  end
+
+  defp do_cleanup_queues(queues, verk_node_id) do
+    Enum.each(queues, &(enqueue_inprogress(verk_node_id, &1)))
+  end
+
+  defp find_faulty_nodes(local_verk_node_id, cursor \\ 0) do
+    case Verk.Node.members(cursor, Verk.Redis) do
+      {:ok, verk_nodes} ->
+        do_find_faulty_nodes(verk_nodes, local_verk_node_id)
+      {:more, verk_nodes, cursor} ->
+        do_find_faulty_nodes(verk_nodes, local_verk_node_id) ++
+        find_faulty_nodes(local_verk_node_id, cursor)
+    end
+  end
+
+  defp do_find_faulty_nodes(verk_nodes, local_verk_node_id) do
+    Enum.filter(verk_nodes, fn verk_node_id ->
+      verk_node_id != local_verk_node_id and Verk.Node.ttl!(verk_node_id, Verk.Redis) < 0
+    end)
+  end
+
+  defp heartbeat!(local_verk_node_id, frequency) do
+    Verk.Node.expire_in!(local_verk_node_id, 2 * frequency, Verk.Redis)
+    Process.send_after(self(), :heartbeat, frequency)
+  end
+
+  defp enqueue_inprogress(node_id, queue) do
+    case InProgressQueue.enqueue_in_progress(queue, node_id, Verk.Redis) do
+      {:ok, [0, m]} ->
+        Logger.info("Added #{m} jobs.")
+        Logger.info("No more jobs to be added to the queue #{queue} from inprogress list.")
+        :ok
+      {:ok, [n, m]} ->
+        Logger.info("Added #{m} jobs.")
+        Logger.info("#{n} jobs still to be added to the queue #{queue} from inprogress list.")
+        enqueue_inprogress(node_id, queue)
+      {:error, reason} ->
+        Logger.error("Failed to add jobs back to queue #{queue} from inprogress. Error: #{inspect reason}")
+        throw :error
+    end
+  end
+end

--- a/lib/verk/queue_supervisor.ex
+++ b/lib/verk/queue_supervisor.ex
@@ -22,7 +22,9 @@ defmodule Verk.Queue.Supervisor do
     children = [
       worker(QueueManager, [queue_manager, name], id: queue_manager),
       poolboy_spec(pool_name, size),
-      worker(WorkersManager, [workers_manager, name, queue_manager, pool_name, size],
+      worker(
+        WorkersManager,
+        [workers_manager, name, queue_manager, pool_name, size],
         id: workers_manager
       )
     ]

--- a/lib/verk/supervisor.ex
+++ b/lib/verk/supervisor.ex
@@ -54,7 +54,9 @@ defmodule Verk.Supervisor do
 
   defp verk_node_id do
     case Application.fetch_env(:verk, :local_node_id) do
-      {:ok, local_verk_node_id} -> local_verk_node_id
+      {:ok, local_verk_node_id} ->
+        local_verk_node_id
+
       :error ->
         if Confex.get_env(:verk, :generate_node_id, false) do
           <<part1::32, part2::32>> = :crypto.strong_rand_bytes(8)

--- a/test/in_progress_queue_test.exs
+++ b/test/in_progress_queue_test.exs
@@ -1,0 +1,23 @@
+defmodule Verk.InProgressQueueTest do
+  use ExUnit.Case
+  import :meck
+  alias Verk.InProgressQueue
+
+  setup do
+    new Redix
+    on_exit fn -> unload() end
+    :ok
+  end
+
+  describe "enqueue_in_progress/3" do
+    test "applies script to the correct keys" do
+      script_sha = Verk.Scripts.sha("lpop_rpush_src_dest")
+      key = "inprogress:queue_name:node_id"
+      commands = [:redis, ["EVALSHA", script_sha, 2, key, "queue:queue_name", 1000]]
+      result = {:ok, []}
+      expect(Redix, :command, commands, result)
+      assert InProgressQueue.enqueue_in_progress("queue_name", "node_id", :redis)
+      assert num_calls(Redix, :command, 2) == 1
+    end
+  end
+end

--- a/test/in_progress_queue_test.exs
+++ b/test/in_progress_queue_test.exs
@@ -4,8 +4,8 @@ defmodule Verk.InProgressQueueTest do
   alias Verk.InProgressQueue
 
   setup do
-    new Redix
-    on_exit fn -> unload() end
+    new(Redix)
+    on_exit(fn -> unload() end)
     :ok
   end
 

--- a/test/manager_test.exs
+++ b/test/manager_test.exs
@@ -3,7 +3,18 @@ defmodule Verk.ManagerTest do
   import :meck
   import Verk.Manager
 
+  @node_id 123
+
+  setup_all do
+    Application.put_env(:verk, :local_node_id, @node_id)
+
+    on_exit(fn ->
+      Application.delete_env(:verk, :local_node_id)
+    end)
+  end
+
   setup do
+    new(Verk.Node, [:merge_expects])
     on_exit(fn -> unload() end)
     :ok
   end
@@ -16,6 +27,8 @@ defmodule Verk.ManagerTest do
   describe "init/1" do
     test "creates an ETS table with queues" do
       queues = [default: 25, low_priority: 10]
+      expect(Verk.Node, :add_queue!, [@node_id, :default, Verk.Redis], :ok)
+      expect(Verk.Node, :add_queue!, [@node_id, :low_priority, Verk.Redis], :ok)
       init(queues)
 
       assert :ets.tab2list(:verk_manager) == [
@@ -115,6 +128,7 @@ defmodule Verk.ManagerTest do
       init_table([])
 
       expect(Verk.Supervisor, :start_child, [:default, 25], {:ok, :child})
+      expect(Verk.Node, :add_queue!, [@node_id, :default, Verk.Redis], :ok)
 
       assert add(:default, 25) == {:ok, :child}
       assert :ets.tab2list(:verk_manager) == [{:default, 25, :running}]
@@ -128,6 +142,7 @@ defmodule Verk.ManagerTest do
       init_table(queues)
 
       expect(Verk.Supervisor, :stop_child, [:default], :ok)
+      expect(Verk.Node, :remove_queue!, [@node_id, :default, Verk.Redis], :ok)
 
       assert remove(:default) == :ok
       assert :ets.tab2list(:verk_manager) == [{:low_priority, 10, :running}]
@@ -139,6 +154,7 @@ defmodule Verk.ManagerTest do
       init_table(queues)
 
       expect(Verk.Supervisor, :stop_child, [:default], {:error, :not_found})
+      expect(Verk.Node, :remove_queue!, [@node_id, :default, Verk.Redis], :ok)
 
       assert remove(:default) == {:error, :not_found}
       assert validate(Verk.Supervisor)

--- a/test/node/manager_test.exs
+++ b/test/node/manager_test.exs
@@ -1,0 +1,70 @@
+defmodule Verk.Node.ManagerTest do
+  use ExUnit.Case
+  alias Verk.InProgressQueue
+  import Verk.Node.Manager
+  import :meck
+
+  @verk_node_id "node-manager-test"
+  @frequency 10
+
+  setup do
+    new [Verk.Node, InProgressQueue], [:merge_expects]
+    Application.put_env(:verk, :local_node_id, @verk_node_id)
+    Application.put_env(:verk, :heartbeat, @frequency)
+
+    on_exit fn ->
+      Application.delete_env(:verk, :local_node_id)
+      Application.delete_env(:verk, :heartbeat)
+      unload()
+    end
+
+    :ok
+  end
+
+  describe "init/1" do
+    test "registers local verk node id" do
+      expect(Verk.Node, :register, [@verk_node_id, 2 * @frequency, Verk.Redis], :ok)
+
+      assert init([]) == {:ok, {@verk_node_id, @frequency}}
+      assert_receive :heartbeat
+    end
+  end
+
+  describe "handle_info/2" do
+    test "heartbeat when only one node" do
+      state = {@verk_node_id, @frequency}
+      expect(Verk.Node, :members, [0, Verk.Redis], {:ok, [@verk_node_id]})
+      expect(Verk.Node, :expire_in!, [@verk_node_id, 2 * @frequency, Verk.Redis], :ok)
+      assert handle_info(:heartbeat, state) == {:noreply, state}
+      assert_receive :heartbeat
+    end
+
+    test "heartbeat when more than 1 node - alive" do
+      alive_node_id = "alive-node"
+      state = {@verk_node_id, @frequency}
+      expect(Verk.Node, :members, [0, Verk.Redis], {:ok, [@verk_node_id, alive_node_id]})
+      expect(Verk.Node, :ttl!, [alive_node_id, Verk.Redis], 500)
+      expect(Verk.Node, :expire_in!, [@verk_node_id, 2 * @frequency, Verk.Redis], :ok)
+      assert handle_info(:heartbeat, state) == {:noreply, state}
+      assert_receive :heartbeat
+    end
+
+    test "heartbeat when more than 1 node - dead" do
+      dead_node_id = "dead-node"
+      state = {@verk_node_id, @frequency}
+
+      expect(Verk.Node, :members, [0, Verk.Redis], {:more, [@verk_node_id], 123})
+      expect(Verk.Node, :members, [123, Verk.Redis], {:ok, [dead_node_id]})
+      expect(Verk.Node, :ttl!, [dead_node_id, Verk.Redis], -2)
+      expect(Verk.Node, :expire_in!, [@verk_node_id, 2 * @frequency, Verk.Redis], :ok)
+      expect(Verk.Node, :queues!, ["dead-node", 0, Verk.Redis], {:more, ["queue_1"], 123})
+      expect(Verk.Node, :queues!, ["dead-node", 123, Verk.Redis], {:ok, ["queue_2"]})
+      expect(InProgressQueue, :enqueue_in_progress, ["queue_1", dead_node_id, Verk.Redis], seq([{:ok, [3, 5]}, {:ok, [0, 3]}]))
+      expect(InProgressQueue, :enqueue_in_progress, ["queue_2", dead_node_id, Verk.Redis], {:ok, [0, 1]})
+      expect(Verk.Node, :deregister!, [dead_node_id, Verk.Redis], :ok)
+
+      assert handle_info(:heartbeat, state) == {:noreply, state}
+      assert_receive :heartbeat
+    end
+  end
+end

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -1,0 +1,122 @@
+defmodule Verk.NodeTest do
+  use ExUnit.Case
+  import Verk.Node
+
+  @verk_nodes_key "verk_nodes"
+
+  @node "123"
+  @node_key "verk:node:123"
+  @node_queues_key "verk:node:123:queues"
+
+  setup do
+    {:ok, redis} = :verk |> Confex.get_env(:redis_url) |> Redix.start_link
+    Redix.command!(redis, ["DEL", @verk_nodes_key, @node_queues_key])
+    {:ok, %{redis: redis}}
+  end
+
+  defp register(%{redis: redis}), do: register(@node, 555, redis)
+
+  describe "register/3" do
+    test "add to verk_nodes", %{redis: redis} do
+      assert register(@node, 555, redis) == :ok
+      assert Redix.command!(redis, ["SMEMBERS", "verk_nodes"]) == ["123"]
+      assert register(@node, 555, redis) == {:error, :node_id_already_running}
+    end
+
+    test "set verk:node: key", %{redis: redis} do
+      assert register(@node, 555, redis) == :ok
+      assert Redix.command!(redis, ["GET", @node_key]) == "alive"
+    end
+
+    test "expire verk:node: key", %{redis: redis} do
+      assert register(@node, 555, redis) == :ok
+      ttl = Redix.command!(redis, ["PTTL", @node_key])
+      assert_in_delta ttl, 555, 5
+    end
+  end
+
+  describe "deregister/2" do
+    setup :register
+
+    test "remove from verk_nodes", %{redis: redis} do
+      assert Redix.command!(redis, ["SMEMBERS", "verk_nodes"]) == ["123"]
+      assert deregister!(@node, redis) == :ok
+      assert Redix.command!(redis, ["SMEMBERS", "verk_nodes"]) == []
+    end
+
+    test "remove verk:node: key", %{redis: redis} do
+      assert Redix.command!(redis, ["GET", @node_key]) == "alive"
+      assert deregister!(@node, redis) == :ok
+      assert Redix.command!(redis, ["GET", @node_key]) == nil
+    end
+
+    test "remove verk:node::queues key", %{redis: redis} do
+      assert Redix.command!(redis, ["SADD", @node_queues_key, "queue_1"]) == 1
+      assert deregister!(@node, redis) == :ok
+      assert Redix.command!(redis, ["GET", @node_queues_key]) == nil
+    end
+  end
+
+  describe "members/3" do
+    setup %{redis: redis} do
+      register("node_1", 555, redis)
+      register("node_2", 555, redis)
+      register("node_3", 555, redis)
+      register("node_4", 555, redis)
+    end
+
+    test "list verk nodes", %{redis: redis} do
+      {:ok, nodes} = members(redis)
+      nodes = MapSet.new(nodes)
+      assert MapSet.equal?(nodes, MapSet.new(["node_1", "node_2", "node_3", "node_4"]))
+    end
+  end
+
+  describe "ttl!/2" do
+    setup :register
+
+    test "return ttl from a verk node id", %{redis: redis} do
+      assert_in_delta ttl!(@node, redis), 555, 5
+    end
+  end
+
+  describe "expire_in!/3" do
+    test "resets expiration item", %{redis: redis} do
+      assert expire_in!(@node, 888, redis)
+      assert_in_delta Redix.command!(redis, ["PTTL", @node_key]), 888, 5
+    end
+  end
+
+  describe "queues!/2" do
+    setup %{redis: redis} do
+      add_queue!(@node, "queue_1", redis)
+      add_queue!(@node, "queue_2", redis)
+      add_queue!(@node, "queue_3", redis)
+      add_queue!(@node, "queue_4", redis)
+      :ok
+    end
+
+    test "list queues", %{redis: redis} do
+      {:ok, queues} = queues!(@node, 0, redis)
+      queues = MapSet.new(queues)
+      assert MapSet.equal?(queues, MapSet.new(["queue_1", "queue_2", "queue_3", "queue_4"]))
+    end
+  end
+
+  describe "add_queue!/3" do
+    test "add queue to verk:node::queues", %{redis: redis} do
+      queue_name = "default"
+      assert add_queue!(@node, queue_name, redis)
+      assert Redix.command!(redis, ["SMEMBERS", @node_queues_key]) == [queue_name]
+    end
+  end
+
+  describe "remove_queue!/3" do
+    test "remove queue from verk:node::queues", %{redis: redis} do
+      queue_name = "default"
+      assert Redix.command!(redis, ["SADD", @node_queues_key, queue_name]) == 1
+      assert remove_queue!(@node, queue_name, redis)
+      assert Redix.command!(redis, ["SMEMBERS", @node_queues_key]) == []
+    end
+  end
+end

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -9,7 +9,7 @@ defmodule Verk.NodeTest do
   @node_queues_key "verk:node:123:queues"
 
   setup do
-    {:ok, redis} = :verk |> Confex.get_env(:redis_url) |> Redix.start_link
+    {:ok, redis} = :verk |> Confex.get_env(:redis_url) |> Redix.start_link()
     Redix.command!(redis, ["DEL", @verk_nodes_key, @node_queues_key])
     {:ok, %{redis: redis}}
   end

--- a/test/queue_manager_test.exs
+++ b/test/queue_manager_test.exs
@@ -5,9 +5,14 @@ defmodule Verk.QueueManagerTest do
   alias Verk.{QueueManager.State, Job, RetrySet, DeadSet}
 
   @mrpop_script Verk.Scripts.sha("mrpop_lpush_src_dest")
+  @node_id "1"
 
   setup do
-    on_exit(fn -> unload() end)
+    Application.put_env(:verk, :local_node_id, @node_id)
+    on_exit fn ->
+      unload()
+      Application.delete_env(:verk, :local_node_id)
+    end
     :ok
   end
 
@@ -21,7 +26,7 @@ defmodule Verk.QueueManagerTest do
   describe "init/1" do
     test "sets up redis connection" do
       redis_url = Confex.get_env(:verk, :redis_url)
-      node_id = Confex.get_env(:verk, :node_id, "1")
+      node_id = Confex.fetch_env!(:verk, :local_node_id)
 
       expect(Redix, :start_link, [redis_url], {:ok, :redis})
       expect(Verk.Scripts, :load, [:redis], :ok)

--- a/test/queue_manager_test.exs
+++ b/test/queue_manager_test.exs
@@ -9,10 +9,12 @@ defmodule Verk.QueueManagerTest do
 
   setup do
     Application.put_env(:verk, :local_node_id, @node_id)
-    on_exit fn ->
+
+    on_exit(fn ->
       unload()
       Application.delete_env(:verk, :local_node_id)
-    end
+    end)
+
     :ok
   end
 

--- a/test/supervisor_test.exs
+++ b/test/supervisor_test.exs
@@ -6,12 +6,14 @@ defmodule Verk.SupervisorTest do
   setup do
     new(Supervisor)
     Application.delete_env(:verk, :local_node_id)
+    Application.delete_env(:verk, :generate_node_id)
     Application.put_env(:verk, :node_id, "123")
 
     on_exit(fn ->
       unload()
       Application.delete_env(:verk, :node_id)
       Application.delete_env(:verk, :local_node_id)
+      Application.delete_env(:verk, :generate_node_id)
     end)
 
     :ok
@@ -20,10 +22,9 @@ defmodule Verk.SupervisorTest do
   describe "init/1" do
     test "defines tree" do
       {:ok, {_, children}} = init([])
-      [redix, node_manager, producer, stats, schedule_manager, manager_sup, drainer] = children
+      [redix, producer, stats, schedule_manager, manager_sup, drainer] = children
 
       assert {Verk.Redis, _, _, _, :worker, [Redix]} = redix
-      assert {Verk.Node.Manager, _, _, _, :worker, [Verk.Node.Manager]} = node_manager
       assert {Verk.EventProducer, _, _, _, :worker, [Verk.EventProducer]} = producer
       assert {Verk.QueueStats, _, _, _, :worker, [Verk.QueueStats]} = stats
       assert {Verk.ScheduleManager, _, _, _, :worker, [Verk.ScheduleManager]} = schedule_manager
@@ -51,6 +52,24 @@ defmodule Verk.SupervisorTest do
       Application.put_env(:verk, :local_node_id, "456")
       assert {:ok, _} = init([])
       assert Application.get_env(:verk, :local_node_id) == "456"
+    end
+
+    test "defines tree with node manager if generate_node_id is true" do
+      Application.put_env(:verk, :generate_node_id, true)
+
+      {:ok, {_, children}} = init([])
+      [redix, node_manager, producer, stats, schedule_manager, manager_sup, drainer] = children
+
+      assert {Verk.Redis, _, _, _, :worker, [Redix]} = redix
+      assert {Verk.Node.Manager, _, _, _, :worker, [Verk.Node.Manager]} = node_manager
+      assert {Verk.EventProducer, _, _, _, :worker, [Verk.EventProducer]} = producer
+      assert {Verk.QueueStats, _, _, _, :worker, [Verk.QueueStats]} = stats
+      assert {Verk.ScheduleManager, _, _, _, :worker, [Verk.ScheduleManager]} = schedule_manager
+
+      assert {Verk.Manager.Supervisor, _, _, _, :supervisor, [Verk.Manager.Supervisor]} =
+               manager_sup
+
+      assert {Verk.QueuesDrainer, _, _, _, :worker, [Verk.QueuesDrainer]} = drainer
     end
   end
 

--- a/test/supervisor_test.exs
+++ b/test/supervisor_test.exs
@@ -5,16 +5,23 @@ defmodule Verk.SupervisorTest do
 
   setup do
     new(Supervisor)
-    on_exit(fn -> unload() end)
+    Application.delete_env(:verk, :local_node_id)
+
+    on_exit(fn ->
+      unload()
+      Application.delete_env(:verk, :local_node_id)
+    end)
+
     :ok
   end
 
   describe "init/1" do
     test "defines tree" do
       {:ok, {_, children}} = init([])
-      [redix, producer, stats, schedule_manager, manager_sup, drainer] = children
+      [redix, node_manager, producer, stats, schedule_manager, manager_sup, drainer] = children
 
       assert {Verk.Redis, _, _, _, :worker, [Redix]} = redix
+      assert {Verk.Node.Manager, _, _, _, :worker, [Verk.Node.Manager]} = node_manager
       assert {Verk.EventProducer, _, _, _, :worker, [Verk.EventProducer]} = producer
       assert {Verk.QueueStats, _, _, _, :worker, [Verk.QueueStats]} = stats
       assert {Verk.ScheduleManager, _, _, _, :worker, [Verk.ScheduleManager]} = schedule_manager
@@ -23,6 +30,18 @@ defmodule Verk.SupervisorTest do
                manager_sup
 
       assert {Verk.QueuesDrainer, _, _, _, :worker, [Verk.QueuesDrainer]} = drainer
+    end
+
+    test "defines local_node_id if not defined" do
+      Application.delete_env(:verk, :node_id)
+      assert {:ok, _} = init([])
+      assert Application.get_env(:verk, :local_node_id) != nil
+    end
+
+    test "defines local_node_id as node_id" do
+      Application.put_env(:verk, :node_id, 123)
+      assert {:ok, _} = init([])
+      assert Application.get_env(:verk, :local_node_id) == 123
     end
   end
 


### PR DESCRIPTION
Hey team here is my first stab at solving this issue: https://github.com/edgurgel/verk/pull/159/files

The idea is:

(frequency) = 60 seconds ?

    On starts Each node generates a new id (We can check if it's actually new by the result of SADD)
        SADD nodes node_id
        PSETEX verk:node:#{node_id} 2 * frequency alive]
    Each time a node starts working on a queue the queue name is added to "node:queues" set;
    Each time a node stops working on a queue the queue name is removed from "node:queues" set;
    Each frequency seconds we set the node key to expire in 2 * frequency
        PSETEX verk:node:#{node_id} 2 * frequency alive]
        Also check for all the keys of all nodes. If the key expired it means that this node is dead.
        To restore we go through all the running queues of that node and enqueue them from progress back to the queue. Each "enqueue back from in progress" is atomic (<3 lua) so we won't have duplicates.

We may need to review some edge cases like what if we still have unfinished jobs while removing a queue from the list of running queues etc but I will work on them case by case

I need to review this as clearly it's just a stab at the final solution. I've played with some instances running locally and so far so good.


Related to https://github.com/edgurgel/verk/issues/157