### PR TITLE
Gracefully pause queues before shutting down

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ otp_release:
   - 19.3
   - 20.0
 script:
-  - MIX_ENV=test mix test --no-start --trace --cover
+  - mix test --no-start --trace --cover
   - MIX_ENV=test mix credo --strict
+  - cd test/integration
+  - mix deps.get
+  - mix test --no-start --trace
 services:
   - redis-server
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ otp_release:
   - 19.3
   - 20.0
 script:
-  - mix test --no-start --trace --cover
+  - mix test --no-start --trace --cover --exclude integration
   - MIX_ENV=test mix credo --strict
   - cd test/integration
   - mix deps.get

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ otp_release:
   - 19.3
   - 20.0
 script:
-  - mix test --no-start --trace --cover --exclude integration
+  - mix test --no-start --trace --cover
   - MIX_ENV=test mix credo --strict
   - cd test/integration
   - mix deps.get
-  - mix test --no-start --trace
+  - mix test --no-start --trace --include integration
 services:
   - redis-server
 sudo: false

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,6 +5,7 @@ config :verk,
   poll_interval: 5000,
   node_id: "1",
   redis_url: "redis://127.0.0.1:6379",
+  shutdown_timeout: 60_000,
   workers_manager_timeout: 1200
   # failed_job_stacktrace_size: 5
 

--- a/lib/verk/event_producer.ex
+++ b/lib/verk/event_producer.ex
@@ -8,6 +8,8 @@ defmodule Verk.EventProducer do
     GenStage.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
+  def stop, do: GenStage.stop(__MODULE__)
+
   def async_notify(event) do
     GenStage.cast(__MODULE__, {:notify, event})
   end

--- a/lib/verk/queues_drainer.ex
+++ b/lib/verk/queues_drainer.ex
@@ -1,0 +1,59 @@
+defmodule Verk.QueuesDrainer do
+  @moduledoc """
+  This process exists to pause queues once a `shutdown` is issued. Once all queues are paused the
+  """
+
+  defmodule Consumer do
+    @moduledoc false
+    use GenStage
+
+    def start_link() do
+      GenStage.start_link(__MODULE__, self())
+    end
+
+    def init(parent) do
+      filter = fn event -> event.__struct__ == Verk.Events.QueuePaused end
+      {:consumer, parent, subscribe_to: [{Verk.EventProducer, selector: filter}]}
+    end
+
+    def handle_events([event], _from, parent) do
+      send parent, {:paused, event.queue}
+      {:noreply, [], parent}
+    end
+  end
+
+  use GenServer
+  require Logger
+
+  def start_link(shutdown_timeout) do
+    GenServer.start_link(__MODULE__, shutdown_timeout)
+  end
+
+  def init(shutdown_timeout) do
+    Process.flag(:trap_exit, true)
+    {:ok, shutdown_timeout}
+  end
+
+  def terminate(:shutdown, shutdown_timeout) do
+    Logger.warn "Pausing all queues. Max timeout: #{shutdown_timeout}"
+
+    {:ok, _pid} = Consumer.start_link()
+
+    queues = for {queue, _, :running} <- Verk.Manager.status(), into: MapSet.new do
+      Verk.pause_queue(queue)
+      queue
+    end
+
+    n_queues = MapSet.size(queues)
+    Logger.warn "Waiting for #{n_queues} queues"
+
+    for x <- (0..n_queues), x > 0 do
+      receive do
+        {:paused, queue} -> Logger.info "Queue #{queue} paused!"
+      end
+    end
+
+    Logger.warn "All queues paused. Shutting down"
+    :ok
+  end
+end

--- a/test/integration/.gitignore
+++ b/test/integration/.gitignore
@@ -1,0 +1,20 @@
+# The directory Mix will write compiled artifacts to.
+/_build
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover
+
+# The directory Mix downloads your dependencies sources to.
+/deps
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,2 @@
+# Integration Tests
+

--- a/test/integration/config/config.exs
+++ b/test/integration/config/config.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :verk, queues: [queue_one: 5, queue_two: 5],
+              redis_url: "redis://127.0.0.1:6379/5",
+              shutdown_timeout: 3_000

--- a/test/integration/lib/integration.ex
+++ b/test/integration/lib/integration.ex
@@ -1,17 +1,4 @@
 defmodule Integration do
-  @moduledoc """
-  Documentation for Integration.
-  """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> Integration.hello
-      :world
-
-  """
   def hello do
     :world
   end

--- a/test/integration/lib/integration.ex
+++ b/test/integration/lib/integration.ex
@@ -1,0 +1,18 @@
+defmodule Integration do
+  @moduledoc """
+  Documentation for Integration.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> Integration.hello
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/test/integration/lib/integration/application.ex
+++ b/test/integration/lib/integration/application.ex
@@ -1,0 +1,16 @@
+defmodule Integration.Application do
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    children = [
+      supervisor(Verk.Supervisor, [])
+    ]
+
+    opts = [strategy: :one_for_one, name: Integration.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/test/integration/lib/integration/no_op_worker.ex
+++ b/test/integration/lib/integration/no_op_worker.ex
@@ -1,0 +1,3 @@
+defmodule Integration.NoOpWorker do
+  def perform, do: :ok
+end

--- a/test/integration/lib/integration/sleep_worker.ex
+++ b/test/integration/lib/integration/sleep_worker.ex
@@ -1,0 +1,5 @@
+defmodule Integration.SleepWorker do
+  def perform(sleep) do
+    :timer.sleep(sleep)
+  end
+end

--- a/test/integration/mix.exs
+++ b/test/integration/mix.exs
@@ -1,0 +1,20 @@
+defmodule Integration.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :integration,
+     version: "0.1.0",
+     elixir: "~> 1.4",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps()]
+  end
+
+  def application do
+    [extra_applications: [:logger], mod: {Integration.Application, []}]
+  end
+
+  defp deps do
+    [{:verk, path: "../../"}]
+  end
+end

--- a/test/integration/mix.lock
+++ b/test/integration/mix.lock
@@ -1,0 +1,6 @@
+%{"confex": {:hex, :confex, "3.2.3", "f3e29188448c790dd75b416daeedddddcce0a9bb657721cd9ed3d857a2de0434", [], [], "hexpm"},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [], [], "hexpm"},
+  "gen_stage": {:hex, :gen_stage, "0.12.2", "e0e347cbb1ceb5f4e68a526aec4d64b54ad721f0a8b30aa9d28e0ad749419cbb", [], [], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [], [], "hexpm"},
+  "redix": {:hex, :redix, "0.7.1", "25a6c1c0d9b2d12a35aef759f9e49bd9bca00e0cd857ce766412f08fdda72163", [], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"}}

--- a/test/integration/test/integration_test.exs
+++ b/test/integration/test/integration_test.exs
@@ -1,7 +1,6 @@
 defmodule IntegrationTest do
   use ExUnit.Case
   alias Verk.Events.{QueueRunning, QueuePausing, QueuePaused}
-  doctest Integration
 
   defmodule Consumer do
     use GenStage
@@ -26,13 +25,14 @@ defmodule IntegrationTest do
     {:ok, redis: redis}
   end
 
+  @tag integration: true
   test "shutdown", %{redis: redis} do
     for _x <- (0..10) do
       Verk.enqueue(%Verk.Job{queue: "queue_one", class: Integration.SleepWorker, args: [1_500]}, redis)
       Verk.enqueue(%Verk.Job{queue: "queue_two", class: Integration.SleepWorker, args: [2_000]}, redis)
     end
     Application.ensure_all_started(:integration)
-    {:ok, consumer} = Consumer.start
+    {:ok, _consumer} = Consumer.start
     Application.stop(:integration)
 
     assert_receive %Verk.Events.QueuePausing{queue: :queue_one}

--- a/test/integration/test/integration_test.exs
+++ b/test/integration/test/integration_test.exs
@@ -1,0 +1,43 @@
+defmodule IntegrationTest do
+  use ExUnit.Case
+  alias Verk.Events.{QueueRunning, QueuePausing, QueuePaused}
+  doctest Integration
+
+  defmodule Consumer do
+    use GenStage
+
+    def start(), do: GenStage.start(__MODULE__, self())
+
+    def init(parent) do
+
+      filter = fn event -> event.__struct__ in [QueueRunning, QueuePausing, QueuePaused] end
+      {:consumer, parent, subscribe_to: [{Verk.EventProducer, selector: filter}]}
+    end
+
+    def handle_events(events, _from, parent) do
+      Enum.each(events, fn event -> send parent, event end)
+      {:noreply, [], parent}
+    end
+  end
+
+  setup_all do
+    {:ok, redis} = Redix.start_link(Confex.get_env(:verk, :redis_url))
+    Redix.command!(redis, ["FLUSHDB"])
+    {:ok, redis: redis}
+  end
+
+  test "shutdown", %{redis: redis} do
+    for _x <- (0..10) do
+      Verk.enqueue(%Verk.Job{queue: "queue_one", class: Integration.SleepWorker, args: [1_500]}, redis)
+      Verk.enqueue(%Verk.Job{queue: "queue_two", class: Integration.SleepWorker, args: [2_000]}, redis)
+    end
+    Application.ensure_all_started(:integration)
+    {:ok, consumer} = Consumer.start
+    Application.stop(:integration)
+
+    assert_receive %Verk.Events.QueuePausing{queue: :queue_one}
+    assert_receive %Verk.Events.QueuePausing{queue: :queue_two}
+    assert_receive %Verk.Events.QueuePaused{queue: :queue_one}
+    assert_receive %Verk.Events.QueuePaused{queue: :queue_two}
+  end
+end

--- a/test/integration/test/test_helper.exs
+++ b/test/integration/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/test/queues_drainer_test.exs
+++ b/test/queues_drainer_test.exs
@@ -1,0 +1,50 @@
+defmodule Verk.QueuesDrainerTest do
+  use ExUnit.Case
+  alias Verk.EventProducer
+  import Verk.QueuesDrainer
+  import :meck
+
+  setup_all do
+    {:ok, pid} = EventProducer.start_link()
+    on_exit fn ->
+      if Process.alive?(pid), do: EventProducer.stop()
+    end
+    :ok
+  end
+
+  setup do
+    new Verk, [:merge_expects]
+    on_exit fn -> unload() end
+    :ok
+  end
+
+  describe "terminate/2" do
+    test "terminate shutdown" do
+      queues = [{:running_queue, 25, :running}, {:paused_queue, 25, :paused}]
+      expect(Verk, :pause_queue, [:running_queue], true)
+      expect(Verk.Manager, :status, 0, queues)
+
+      EventProducer.async_notify(%Verk.Events.QueuePaused{queue: :running_queue})
+
+      assert terminate(:shutdown, 2000) == :ok
+    end
+
+    test "terminate normal" do
+      queues = [{:running_queue, 25, :running}, {:paused_queue, 25, :paused}]
+      expect(Verk, :pause_queue, [:running_queue], true)
+      expect(Verk.Manager, :status, 0, queues)
+
+      EventProducer.async_notify(%Verk.Events.QueuePaused{queue: :running_queue})
+
+      assert terminate(:normal, 2000) == :ok
+    end
+
+    test "terminate shutdown timeout" do
+      queues = [{:running_queue, 25, :running}, {:paused_queue, 25, :paused}]
+      expect(Verk, :pause_queue, [:running_queue], true)
+      expect(Verk.Manager, :status, 0, queues)
+
+      assert catch_throw(terminate(:shutdown, 2000)) == :shutdown_timeout
+    end
+  end
+end

--- a/test/supervisor_test.exs
+++ b/test/supervisor_test.exs
@@ -12,13 +12,14 @@ defmodule Verk.SupervisorTest do
   describe "init/1" do
     test "defines tree" do
       {:ok, {_, children}} = init([])
-      [redix, producer, stats, schedule_manager, manager_sup] = children
+      [redix, producer, stats, schedule_manager, manager_sup, drainer] = children
 
       assert {Verk.Redis, _, _, _, :worker, [Redix]} = redix
       assert {Verk.EventProducer, _, _, _, :worker, [Verk.EventProducer]} = producer
       assert {Verk.QueueStats, _, _, _, :worker, [Verk.QueueStats]} = stats
       assert {Verk.ScheduleManager, _, _, _, :worker, [Verk.ScheduleManager]} = schedule_manager
       assert {Verk.Manager.Supervisor, _, _, _, :supervisor, [Verk.Manager.Supervisor]} = manager_sup
+      assert {Verk.QueuesDrainer, _, _, _, :worker, [Verk.QueuesDrainer]} = drainer
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+ExUnit.configure(exclude: [integration: true])


### PR DESCRIPTION
This PR changes the way `Verk` will shutdown. It uses a `GenStage` consumer to watch for all the queues that should be paused. Waiting a max of `shutdown_timeout`

It fixes https://github.com/edgurgel/verk/issues/96

cc/ @krasio 