### PR TITLE
Bump confex version to support documented config

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule Verk.Mixfile do
     [{ :redix, ">= 0.6.0 and < 0.8.0" },
      { :jason, "~> 1.0" },
      { :poolboy, "~> 1.5.1" },
-     { :confex, "~> 3.2.0" },
+     { :confex, "~> 3.3.0" },
      { :gen_stage, "~> 0.12.1" },
      { :credo, "~> 0.9", only: [:dev, :test] },
      { :earmark, "~> 1.0", only: :dev },

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "combine": {:hex, :combine, "0.9.2", "cd3c8721f378ebe032487d8a4fa2ced3181a456a3c21b16464da8c46904bb552", [:mix], []},
-  "confex": {:hex, :confex, "3.2.2", "4fc6161d1bbbe3f24581758059dce285fa9d2719fe41a15b396c4f32250ef7c1", [:mix], [], "hexpm"},
+  "confex": {:hex, :confex, "3.3.1", "8febaf751bf293a16a1ed2cbd258459cdcc7ca53cfa61d3f83d49dd276a992b4", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "coverex": {:hex, :coverex, "1.4.13", "d90833b82bdd6a1ec05a6d971283debc3dd9611957489010e4b1ab0071a9ee6c", [:mix], [{:hackney, "~> 1.5", [hex: :hackney, repo: "hexpm", optional: false]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "credo": {:hex, :credo, "0.9.2", "841d316612f568beb22ba310d816353dddf31c2d94aa488ae5a27bb53760d0bf", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
The documentation suggests that you do the following:

```elixir
config :verk,
  queues: {:system, {MyApp.Env, :verk_queues, []}, "VERK_DISABLED"}

defmodule MyApp.Env do
  def verk_queues("true"), do: []
  def verk_queues(_), do: [default: 25, priority: 10]
end
```

Unfortunately this MFA style configuration was only introduced in confex 3.3. I have bumped the version of confex to `~> 3.3.0` so the documentation is correct. Is that any reason we can't bump to `~> 3.3`?