### PR TITLE
Over writable configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The queue `default` will have a maximum of 25 jobs being processed at a time and
 ```elixir
 config :verk, queues: [default: 25, priority: 10],
               max_retry_count: 10,
+              max_dead_jobs: 100,
               poll_interval: 5000,
               start_job_log_level: :info,
               done_job_log_level: :info,
@@ -84,6 +85,7 @@ Verk supports the convention `{:system, "ENV_NAME", default}` for reading enviro
 ```elixir
 config :verk, queues: [default: 25, priority: 10],
               max_retry_count: 10,
+              max_dead_jobs: 100,
               poll_interval: {:system, :integer, "VERK_POLL_INTERVAL", 5000},
               start_job_log_level: :info,
               done_job_log_level: :info,

--- a/lib/verk/dead_set.ex
+++ b/lib/verk/dead_set.ex
@@ -1,6 +1,9 @@
 defmodule Verk.DeadSet do
   @moduledoc """
-  This module interacts with jobs in the dead set
+  This module interacts with jobs in the dead set.
+
+  Set `config :verk, max_dead_jobs: value` on your config file to set the max
+  amount of dead jobs to be stored on your dead queue. Defaults at `100`.
   """
   import Verk.Dsl
   alias Verk.{SortedSet, Job}

--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -3,14 +3,33 @@ defmodule Verk.Job do
   The Job struct
   """
 
-  @default_max_retry_count Confex.get_env(:verk, :max_retry_count, 25)
-  @keys [error_message: nil, failed_at: nil, retry_count: 0, queue: nil, class: nil, args: [],
-         jid: nil, finished_at: nil, enqueued_at: nil, retried_at: nil, created_at: nil, error_backtrace: nil,
-         max_retry_count: @default_max_retry_count]
+  @keys [
+    error_message: nil,
+    failed_at: nil,
+    retry_count: 0,
+    queue: nil,
+    class: nil,
+    args: [],
+    jid: nil,
+    finished_at: nil,
+    enqueued_at: nil,
+    retried_at: nil,
+    created_at: nil,
+    error_backtrace: nil,
+    max_retry_count: nil
+  ]
 
-  @type t :: %__MODULE__{error_message: String.t, failed_at: DateTime.t, retry_count: non_neg_integer,
-                         queue: String.t, class: String.t | atom, jid: String.t, finished_at: DateTime.t,
-                         retried_at: DateTime.t, error_backtrace: String.t}
+  @type t :: %__MODULE__{
+          error_message: String.t(),
+          failed_at: DateTime.t(),
+          retry_count: non_neg_integer,
+          queue: String.t(),
+          class: String.t() | atom,
+          jid: String.t(),
+          finished_at: DateTime.t(),
+          retried_at: DateTime.t(),
+          error_backtrace: String.t()
+        }
   defstruct [:original_json | @keys]
 
   @doc """
@@ -38,10 +57,12 @@ defmodule Verk.Job do
         map
         |> Map.update!("args", fn _ -> args end)
         |> Map.new(fn {k, v} -> {String.to_existing_atom(k), v} end)
+
       job =
         %__MODULE__{}
         |> struct(fields)
         |> build(payload)
+
       {:ok, job}
     end
   end
@@ -58,10 +79,12 @@ defmodule Verk.Job do
   end
 
   def default_max_retry_count do
-    @default_max_retry_count
+    Confex.get_env(:verk, :max_retry_count, 25)
   end
 
-  defp unwrap_args(wrapped_args) when is_binary(wrapped_args), do: Jason.decode(wrapped_args, keys: Application.get_env(:verk, :args_keys, :strings))
+  defp unwrap_args(wrapped_args) when is_binary(wrapped_args),
+    do: Jason.decode(wrapped_args, keys: Application.get_env(:verk, :args_keys, :strings))
+
   defp unwrap_args(args), do: {:ok, args}
 
   defp build(job = %{args: %{}}, payload) do

--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -1,6 +1,9 @@
 defmodule Verk.Job do
   @moduledoc """
-  The Job struct
+  The Job struct.
+
+  Set `config :verk, max_retry_count: value` on your config file to set the default max
+  amount of retries on all your `Verk.Job` when none is informed. Defaults at `25`.
   """
 
   @keys [

--- a/test/job_test.exs
+++ b/test/job_test.exs
@@ -3,7 +3,13 @@ defmodule Verk.JobTest do
   alias Verk.Job
 
   describe "encode!/1" do
-    @job %Job{queue: "test_queue", class: "DummyWorker", args: [1, 2, 3], original_json: "json_payload", max_retry_count: 5}
+    @job %Job{
+      queue: "test_queue",
+      class: "DummyWorker",
+      args: [1, 2, 3],
+      original_json: "json_payload",
+      max_retry_count: 5
+    }
     test "returns a valid json string" do
       result = Job.encode!(@job)
       assert {:ok, _} = Jason.decode(result)
@@ -15,7 +21,12 @@ defmodule Verk.JobTest do
         |> Job.encode!()
         |> Jason.decode!()
 
-      assert %{"queue" => "test_queue", "class" => "DummyWorker", "args" => "[1,2,3]", "max_retry_count" => 5} = map
+      assert %{
+               "queue" => "test_queue",
+               "class" => "DummyWorker",
+               "args" => "[1,2,3]",
+               "max_retry_count" => 5
+             } = map
     end
 
     test "does not encode the original json" do
@@ -36,6 +47,56 @@ defmodule Verk.JobTest do
       assert is_binary(map["args"])
       assert {:ok, _} = Jason.decode(map["args"])
     end
+
+    test "Uses default options if none passed" do
+      map =
+        Job.encode!(%Verk.Job{})
+        |> Job.decode!()
+
+      assert map ==
+               %Verk.Job{
+                 args: [],
+                 class: nil,
+                 created_at: nil,
+                 enqueued_at: nil,
+                 error_backtrace: nil,
+                 error_message: nil,
+                 failed_at: nil,
+                 finished_at: nil,
+                 jid: nil,
+                 max_retry_count: nil,
+                 original_json:
+                   "{\"args\":\"[]\",\"class\":null,\"created_at\":null,\"enqueued_at\":null,\"error_backtrace\":null,\"error_message\":null,\"failed_at\":null,\"finished_at\":null,\"jid\":null,\"max_retry_count\":null,\"queue\":null,\"retried_at\":null,\"retry_count\":0}",
+                 queue: nil,
+                 retried_at: nil,
+                 retry_count: 0
+               }
+    end
+
+    test "Overrides configurations if they are passed" do
+      map =
+        Job.encode!(%Verk.Job{max_retry_count: 5, queue: :default})
+        |> Job.decode!()
+
+      assert map ==
+               %Verk.Job{
+                 args: [],
+                 class: nil,
+                 created_at: nil,
+                 enqueued_at: nil,
+                 error_backtrace: nil,
+                 error_message: nil,
+                 failed_at: nil,
+                 finished_at: nil,
+                 jid: nil,
+                 max_retry_count: 5,
+                 original_json:
+                   "{\"args\":\"[]\",\"class\":null,\"created_at\":null,\"enqueued_at\":null,\"error_backtrace\":null,\"error_message\":null,\"failed_at\":null,\"finished_at\":null,\"jid\":null,\"max_retry_count\":5,\"queue\":\"default\"\,\"retried_at\":null,\"retry_count\":0}",
+                 queue: "default",
+                 retried_at: nil,
+                 retry_count: 0
+               }
+    end
   end
 
   describe "decode!/1" do
@@ -43,14 +104,24 @@ defmodule Verk.JobTest do
       payload = ~s({ "queue" : "test_queue", "args" : "[1, 2, 3]",
                    "max_retry_count" : 5})
 
-      assert Job.decode!(payload) == %Job{ queue: "test_queue", args: [1, 2, 3], original_json: payload, max_retry_count: 5}
+      assert Job.decode!(payload) == %Job{
+               queue: "test_queue",
+               args: [1, 2, 3],
+               original_json: payload,
+               max_retry_count: 5
+             }
     end
 
     test "replaces map with array when job has no args" do
       payload = ~s({ "queue" : "test_queue", "args" : "{}",
                    "max_retry_count" : 5})
 
-      assert Job.decode!(payload) == %Job{ queue: "test_queue", args: [], original_json: payload, max_retry_count: 5}
+      assert Job.decode!(payload) == %Job{
+               queue: "test_queue",
+               args: [],
+               original_json: payload,
+               max_retry_count: 5
+             }
     end
   end
 
@@ -59,7 +130,14 @@ defmodule Verk.JobTest do
       payload = ~s({ "queue" : "test_queue", "args" : "[1, 2, 3]",
                    "max_retry_count" : 5})
 
-      assert Job.decode(payload) == {:ok, %Job{ queue: "test_queue", args: [1, 2, 3], original_json: payload, max_retry_count: 5}}
+      assert Job.decode(payload) ==
+               {:ok,
+                %Job{
+                  queue: "test_queue",
+                  args: [1, 2, 3],
+                  original_json: payload,
+                  max_retry_count: 5
+                }}
     end
 
     test "json decode error returns error tuple" do
@@ -73,7 +151,21 @@ defmodule Verk.JobTest do
       payload = ~s({ "queue" : "test_queue", "args" : "{}",
                    "max_retry_count" : 5})
 
-      assert Job.decode(payload) == {:ok, %Job{ queue: "test_queue", args: [], original_json: payload, max_retry_count: 5}}
+      assert Job.decode(payload) ==
+               {:ok,
+                %Job{queue: "test_queue", args: [], original_json: payload, max_retry_count: 5}}
+    end
+  end
+
+  describe "default_max_retry_count/0" do
+    test "returns 25 if max_retry_count is not set" do
+      assert Verk.Job.default_max_retry_count() == 25
+    end
+
+    test "returns the set max_retry_count value" do
+      Application.put_env(:verk, :max_retry_count, 100)
+      assert Verk.Job.default_max_retry_count() == 100
+      Application.put_env(:verk, :max_retry_count, 25)
     end
   end
 end

--- a/test/verk_test.exs
+++ b/test/verk_test.exs
@@ -5,7 +5,7 @@ defmodule VerkTest do
   alias Verk.{Time, Manager}
 
   setup do
-    on_exit fn -> unload() end
+    on_exit(fn -> unload() end)
     :ok
   end
 
@@ -17,7 +17,7 @@ defmodule VerkTest do
 
       assert add_queue(queue, 30) == {:ok, :child}
 
-      assert validate Manager
+      assert validate(Manager)
     end
   end
 
@@ -29,7 +29,7 @@ defmodule VerkTest do
 
       assert remove_queue(queue) == :ok
 
-      assert validate Manager
+      assert validate(Manager)
     end
 
     test "returns false if failed to remove" do
@@ -39,124 +39,175 @@ defmodule VerkTest do
 
       assert remove_queue(queue) == {:error, :not_found}
 
-      assert validate Manager
+      assert validate(Manager)
     end
   end
 
   describe "enqueue/2" do
     test "a job with a jid and a queue passing redis connection" do
-      job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker",
-        args: [], max_retry_count: 1 }
-      now = Time.now
+      job = %Verk.Job{
+        queue: "test_queue",
+        jid: "job_id",
+        class: "TestWorker",
+        args: [],
+        max_retry_count: 1
+      }
+
+      now = Time.now()
       encoded_job = "encoded_job"
-      expected_job = %Verk.Job{ job | enqueued_at: now |> DateTime.to_unix }
+      expected_job = %Verk.Job{job | enqueued_at: now |> DateTime.to_unix()}
 
       expect(Time, :now, [], now)
       expect(Verk.Job, :encode!, [expected_job], encoded_job)
-      expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })
+      expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], {:ok, :_})
 
-      assert enqueue(job, Verk.Redis) == { :ok, "job_id" }
+      assert enqueue(job, Verk.Redis) == {:ok, "job_id"}
 
-      assert validate [Verk.Job, Redix, Time]
+      assert validate([Verk.Job, Redix, Time])
     end
 
     test "a job with a jid and a queue passing no redis connection" do
-      job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker",
-        args: [], max_retry_count: 1 }
-      now = Time.now
+      job = %Verk.Job{
+        queue: "test_queue",
+        jid: "job_id",
+        class: "TestWorker",
+        args: [],
+        max_retry_count: 1
+      }
+
+      now = Time.now()
       encoded_job = "encoded_job"
-      expected_job = %Verk.Job{ job | enqueued_at: now |> DateTime.to_unix }
+      expected_job = %Verk.Job{job | enqueued_at: now |> DateTime.to_unix()}
 
       expect(Time, :now, [], now)
       expect(Verk.Job, :encode!, [expected_job], encoded_job)
-      expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })
+      expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], {:ok, :_})
 
-      assert enqueue(job) == { :ok, "job_id" }
+      assert enqueue(job) == {:ok, "job_id"}
 
-      assert validate [Verk.Job, Redix, Time]
+      assert validate([Verk.Job, Redix, Time])
     end
 
     test "a job with a jid and a queue" do
-      job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker",
-        args: [], max_retry_count: 1 }
-      now = Time.now
+      job = %Verk.Job{
+        queue: "test_queue",
+        jid: "job_id",
+        class: "TestWorker",
+        args: [],
+        max_retry_count: 1
+      }
+
+      now = Time.now()
       encoded_job = "encoded_job"
-      expected_job = %Verk.Job{ job | enqueued_at: now |> DateTime.to_unix }
+      expected_job = %Verk.Job{job | enqueued_at: now |> DateTime.to_unix()}
 
       expect(Time, :now, [], now)
       expect(Verk.Job, :encode!, [expected_job], encoded_job)
-      expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })
+      expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], {:ok, :_})
 
-      assert enqueue(job) == { :ok, "job_id" }
+      assert enqueue(job) == {:ok, "job_id"}
 
-      assert validate [Verk.Job, Redix, Time]
+      assert validate([Verk.Job, Redix, Time])
     end
 
     test "a job without a jid" do
-      job = %Verk.Job{ queue: "test_queue", class: "TestWorker", args: [], jid: nil }
+      job = %Verk.Job{queue: "test_queue", class: "TestWorker", args: [], jid: nil}
       encoded_job = "encoded_job"
 
       expect(Verk.Job, :encode!, 1, encoded_job)
-      expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], { :ok, :_ })
+      expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], {:ok, :_})
 
-      { :ok, jid } = enqueue(job)
+      {:ok, jid} = enqueue(job)
 
       assert is_binary(jid)
     end
 
-    test "a job without a queue" do
-      job = %Verk.Job{ queue: nil, jid: "job_id" }
+    test "a job without a max_retry_count" do
+      Application.put_env(:verk, :max_retry_count, 100)
+      job = %Verk.Job{queue: "test_queue", class: "TestWorker"}
+      encoded_job = "encoded_job"
 
-      assert enqueue(job) == { :error, { :missing_queue, job } }
+      expect(Verk.Job, :encode!, 1, encoded_job)
+      expect(Redix, :command, [Verk.Redis, ["LPUSH", "queue:test_queue", encoded_job]], {:ok, :_})
+
+      {:ok, jid} = enqueue(job)
+      %Verk.Job{max_retry_count: max_retry_count} = capture(:first, Verk.Job, :encode!, [:_], 1)
+
+      assert max_retry_count == 100
+      assert is_binary(jid)
+      Application.put_env(:verk, :max_retry_count, 25)
+    end
+
+    test "a job without a queue" do
+      job = %Verk.Job{queue: nil, jid: "job_id"}
+
+      assert enqueue(job) == {:error, {:missing_queue, job}}
     end
 
     test "a job with non-list args" do
-      job = %Verk.Job{ queue: "queue", jid: "job_id", class: "TestWorker", args: 123 }
+      job = %Verk.Job{queue: "queue", jid: "job_id", class: "TestWorker", args: 123}
 
-      assert enqueue(job) == { :error, { :missing_args, job } }
+      assert enqueue(job) == {:error, {:missing_args, job}}
     end
 
     test "a job with no module to perform" do
-      job = %Verk.Job{ queue: "queue", jid: "job_id", args: [123], class: nil }
+      job = %Verk.Job{queue: "queue", jid: "job_id", args: [123], class: nil}
 
-      assert enqueue(job) == { :error, { :missing_module, job } }
+      assert enqueue(job) == {:error, {:missing_module, job}}
     end
 
     test "a job with non-integer max_retry_count" do
-      job = %Verk.Job{ queue: "queue", jid: "job_id", class: "TestWorker",
-        args: [123], max_retry_count: "30" }
+      job = %Verk.Job{
+        queue: "queue",
+        jid: "job_id",
+        class: "TestWorker",
+        args: [123],
+        max_retry_count: "30"
+      }
 
-      assert enqueue(job) == { :error, { :invalid_max_retry_count, job } }
+      assert enqueue(job) == {:error, {:invalid_max_retry_count, job}}
     end
   end
 
   describe "schedule/2" do
     test "a job with a jid, a queue and a perform_in" do
-      now = Time.now
+      now = Time.now()
       perform_at = Time.shift(now, 100)
-      job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker", args: [] }
+      job = %Verk.Job{queue: "test_queue", jid: "job_id", class: "TestWorker", args: []}
       encoded_job = "encoded_job"
       expect(Verk.Job, :encode!, [job], encoded_job)
       perform_at_secs = DateTime.to_unix(perform_at)
-      expect(Redix, :command, [Verk.Redis, ["ZADD", "schedule", perform_at_secs, encoded_job]], { :ok, :_ })
 
-      assert schedule(job, perform_at) == { :ok, "job_id" }
+      expect(
+        Redix,
+        :command,
+        [Verk.Redis, ["ZADD", "schedule", perform_at_secs, encoded_job]],
+        {:ok, :_}
+      )
 
-      assert validate [Verk.Job, Redix]
+      assert schedule(job, perform_at) == {:ok, "job_id"}
+
+      assert validate([Verk.Job, Redix])
     end
 
     test "a job with a jid, a queue and a perform_in passing a redis connection" do
-      now = Time.now
+      now = Time.now()
       perform_at = Time.shift(now, 100, :seconds)
-      job = %Verk.Job{ queue: "test_queue", jid: "job_id", class: "TestWorker", args: [] }
+      job = %Verk.Job{queue: "test_queue", jid: "job_id", class: "TestWorker", args: []}
       encoded_job = "encoded_job"
       expect(Verk.Job, :encode!, [job], encoded_job)
       perform_at_secs = DateTime.to_unix(perform_at, :seconds)
-      expect(Redix, :command, [Verk.Redis, ["ZADD", "schedule", perform_at_secs, encoded_job]], { :ok, :_ })
 
-      assert schedule(job, perform_at, Verk.Redis) == { :ok, "job_id" }
+      expect(
+        Redix,
+        :command,
+        [Verk.Redis, ["ZADD", "schedule", perform_at_secs, encoded_job]],
+        {:ok, :_}
+      )
 
-      assert validate [Verk.Job, Redix]
+      assert schedule(job, perform_at, Verk.Redis) == {:ok, "job_id"}
+
+      assert validate([Verk.Job, Redix])
     end
   end
 end


### PR DESCRIPTION
This PR aims to solve issues #170 and #174.

Both `max_retry_count` and `max_dead_jobs` are now over writable by the client as they are no longer associated with a constant, thus evaluated on runtime.

Also this PR updates the documentation, using `max_dead_jobs` on the readme example configuration and explaining both these configurations on the modules they are used at.