### PR TITLE
fix(elixir): Fix unused vars, chunk_every

### DIFF
--- a/lib/verk/sorted_set.ex
+++ b/lib/verk/sorted_set.ex
@@ -80,7 +80,7 @@ defmodule Verk.SortedSet do
         # The Redis returned list alternates, [<job>, <job score>, ...].
         jobs_with_scores =
           jobs
-          |> Enum.chunk_every(2)
+          |> Enum.chunk(2)
           |> Enum.into([], fn [job, score] -> {Job.decode!(job), String.to_integer(score)} end)
 
         {:ok, jobs_with_scores}

--- a/lib/verk/sorted_set.ex
+++ b/lib/verk/sorted_set.ex
@@ -80,7 +80,7 @@ defmodule Verk.SortedSet do
         # The Redis returned list alternates, [<job>, <job score>, ...].
         jobs_with_scores =
           jobs
-          |> Enum.chunk(2)
+          |> Enum.chunk_every(2)
           |> Enum.into([], fn [job, score] -> {Job.decode!(job), String.to_integer(score)} end)
 
         {:ok, jobs_with_scores}


### PR DESCRIPTION
While compiling, I had these deprecations:
```
Compiling 24 files (.ex)
warning: variable "reason" is unused
  lib/verk/queues_drainer.ex:49

warning: variable "shutdown_timeout" is unused
  lib/verk/queues_drainer.ex:49

warning: Enum.chunk/2 is deprecated. Use Enum.chunk_every/2 instead
  lib/verk/sorted_set.ex:82
```

I realize _chunk_ is for older OTP versions. I assume the project doesn't want to deprecate until actually necessary?