### PR TITLE
Resilient verk improvements

### DIFF
--- a/lib/verk/manager.ex
+++ b/lib/verk/manager.ex
@@ -16,11 +16,9 @@ defmodule Verk.Manager do
   @doc false
   def init(queues) do
     ets = :ets.new(@table, @ets_options)
-    local_verk_node_id = Application.fetch_env!(:verk, :local_node_id)
 
     for {queue, size} <- queues do
       :ets.insert_new(@table, {queue, size, :running})
-      Verk.Node.add_queue!(local_verk_node_id, queue, Verk.Redis)
     end
 
     {:ok, ets}
@@ -75,8 +73,6 @@ defmodule Verk.Manager do
       Logger.error("Queue #{queue} is already running")
     end
 
-    local_verk_node_id = Application.fetch_env!(:verk, :local_node_id)
-    Verk.Node.add_queue!(local_verk_node_id, queue, Verk.Redis)
     Verk.Manager.Supervisor.start_child(queue, size)
   end
 
@@ -87,8 +83,6 @@ defmodule Verk.Manager do
   @spec remove(atom) :: :ok | {:error, :not_found}
   def remove(queue) do
     :ets.delete(@table, queue)
-    local_verk_node_id = Application.fetch_env!(:verk, :local_node_id)
-    Verk.Node.remove_queue!(local_verk_node_id, queue, Verk.Redis)
     Verk.Manager.Supervisor.stop_child(queue)
   end
 end

--- a/lib/verk/node.ex
+++ b/lib/verk/node.ex
@@ -66,6 +66,17 @@ defmodule Verk.Node do
   @doc """
   Redis command to add a queue to the set of queues that a node is processing
 
+      iex> Verk.Node.add_queue_redis_command("123", "default")
+      ["SADD", "verk:node:123:queues", "default"]
+  """
+  @spec add_queue_redis_command(String.t(), String.t()) :: [String.t()]
+  def add_queue_redis_command(verk_node_id, queue) do
+    ["SADD", verk_node_queues_key(verk_node_id), queue]
+  end
+
+  @doc """
+  Redis command to add a queue to the set of queues that a node is processing
+
       iex> Verk.Node.add_node_redis_command("123")
       ["SADD", "verk_nodes", "123"]
   """

--- a/lib/verk/node.ex
+++ b/lib/verk/node.ex
@@ -5,18 +5,6 @@ defmodule Verk.Node do
 
   @verk_nodes_key "verk_nodes"
 
-  @spec register(String.t(), non_neg_integer, GenServer.t()) ::
-          :ok | {:error, :verk_node_id_already_running}
-  def register(verk_node_id, ttl, redis) do
-    case Redix.pipeline!(redis, [
-           ["SADD", @verk_nodes_key, verk_node_id],
-           ["PSETEX", "verk:node:#{verk_node_id}", ttl, "alive"]
-         ]) do
-      [1, _] -> :ok
-      _ -> {:error, :node_id_already_running}
-    end
-  end
-
   @spec deregister!(String.t(), GenServer.t()) :: :ok
   def deregister!(verk_node_id, redis) do
     Redix.pipeline!(redis, [

--- a/lib/verk/node.ex
+++ b/lib/verk/node.ex
@@ -85,14 +85,6 @@ defmodule Verk.Node do
     ["SADD", @verk_nodes_key, verk_node_id]
   end
 
-  def add_queue!(verk_node_id, queue, redis) do
-    Redix.command!(redis, ["SADD", verk_node_queues_key(verk_node_id), queue])
-  end
-
-  def remove_queue!(verk_node_id, queue, redis) do
-    Redix.command!(redis, ["SREM", verk_node_queues_key(verk_node_id), queue])
-  end
-
   defp verk_node_key(verk_node_id), do: "verk:node:#{verk_node_id}"
   defp verk_node_queues_key(verk_node_id), do: "verk:node:#{verk_node_id}:queues"
 end

--- a/lib/verk/node.ex
+++ b/lib/verk/node.ex
@@ -63,6 +63,17 @@ defmodule Verk.Node do
     end
   end
 
+  @doc """
+  Redis command to add a queue to the set of queues that a node is processing
+
+      iex> Verk.Node.add_node_redis_command("123")
+      ["SADD", "verk_nodes", "123"]
+  """
+  @spec add_node_redis_command(String.t()) :: [String.t()]
+  def add_node_redis_command(verk_node_id) do
+    ["SADD", @verk_nodes_key, verk_node_id]
+  end
+
   def add_queue!(verk_node_id, queue, redis) do
     Redix.command!(redis, ["SADD", verk_node_queues_key(verk_node_id), queue])
   end

--- a/lib/verk/node/manager.ex
+++ b/lib/verk/node/manager.ex
@@ -19,7 +19,8 @@ defmodule Verk.Node.Manager do
       "Node Manager started for node #{local_verk_node_id}. Heartbeat will run every #{frequency} milliseconds"
     )
 
-    :ok = Verk.Node.register(local_verk_node_id, 2 * frequency, Verk.Redis)
+    heartbeat(local_verk_node_id, frequency)
+
     Process.send_after(self(), :heartbeat, frequency)
     Process.flag(:trap_exit, true)
     Verk.Scripts.load(Verk.Redis)

--- a/test/manager_test.exs
+++ b/test/manager_test.exs
@@ -27,8 +27,6 @@ defmodule Verk.ManagerTest do
   describe "init/1" do
     test "creates an ETS table with queues" do
       queues = [default: 25, low_priority: 10]
-      expect(Verk.Node, :add_queue!, [@node_id, :default, Verk.Redis], :ok)
-      expect(Verk.Node, :add_queue!, [@node_id, :low_priority, Verk.Redis], :ok)
       init(queues)
 
       assert :ets.tab2list(:verk_manager) == [
@@ -128,7 +126,6 @@ defmodule Verk.ManagerTest do
       init_table([])
 
       expect(Verk.Manager.Supervisor, :start_child, [:default, 25], {:ok, :child})
-      expect(Verk.Node, :add_queue!, [@node_id, :default, Verk.Redis], :ok)
 
       assert add(:default, 25) == {:ok, :child}
       assert :ets.tab2list(:verk_manager) == [{:default, 25, :running}]
@@ -142,7 +139,6 @@ defmodule Verk.ManagerTest do
       init_table(queues)
 
       expect(Verk.Manager.Supervisor, :stop_child, [:default], :ok)
-      expect(Verk.Node, :remove_queue!, [@node_id, :default, Verk.Redis], :ok)
 
       assert remove(:default) == :ok
       assert :ets.tab2list(:verk_manager) == [{:low_priority, 10, :running}]
@@ -154,7 +150,6 @@ defmodule Verk.ManagerTest do
       init_table(queues)
 
       expect(Verk.Manager.Supervisor, :stop_child, [:default], {:error, :not_found})
-      expect(Verk.Node, :remove_queue!, [@node_id, :default, Verk.Redis], :ok)
 
       assert remove(:default) == {:error, :not_found}
       assert validate(Verk.Manager.Supervisor)

--- a/test/node/manager_test.exs
+++ b/test/node/manager_test.exs
@@ -23,7 +23,7 @@ defmodule Verk.Node.ManagerTest do
 
   describe "init/1" do
     test "registers local verk node id" do
-      expect(Verk.Node, :register, [@verk_node_id, 2 * @frequency, Verk.Redis], :ok)
+      expect(Verk.Node, :expire_in, [@verk_node_id, 2 * @frequency, Verk.Redis], {:ok, 1})
       expect(Verk.Scripts, :load, 1, :ok)
 
       assert init([]) == {:ok, {@verk_node_id, @frequency}}

--- a/test/node/manager_test.exs
+++ b/test/node/manager_test.exs
@@ -35,7 +35,7 @@ defmodule Verk.Node.ManagerTest do
     test "heartbeat when only one node" do
       state = {@verk_node_id, @frequency}
       expect(Verk.Node, :members, [0, Verk.Redis], {:ok, [@verk_node_id]})
-      expect(Verk.Node, :expire_in!, [@verk_node_id, 2 * @frequency, Verk.Redis], :ok)
+      expect(Verk.Node, :expire_in, [@verk_node_id, 2 * @frequency, Verk.Redis], {:ok, 1})
       assert handle_info(:heartbeat, state) == {:noreply, state}
       assert_receive :heartbeat
     end
@@ -45,7 +45,7 @@ defmodule Verk.Node.ManagerTest do
       state = {@verk_node_id, @frequency}
       expect(Verk.Node, :members, [0, Verk.Redis], {:ok, [@verk_node_id, alive_node_id]})
       expect(Verk.Node, :ttl!, [alive_node_id, Verk.Redis], 500)
-      expect(Verk.Node, :expire_in!, [@verk_node_id, 2 * @frequency, Verk.Redis], :ok)
+      expect(Verk.Node, :expire_in, [@verk_node_id, 2 * @frequency, Verk.Redis], {:ok, 1})
       assert handle_info(:heartbeat, state) == {:noreply, state}
       assert_receive :heartbeat
     end
@@ -57,7 +57,7 @@ defmodule Verk.Node.ManagerTest do
       expect(Verk.Node, :members, [0, Verk.Redis], {:more, [@verk_node_id], 123})
       expect(Verk.Node, :members, [123, Verk.Redis], {:ok, [dead_node_id]})
       expect(Verk.Node, :ttl!, [dead_node_id, Verk.Redis], -2)
-      expect(Verk.Node, :expire_in!, [@verk_node_id, 2 * @frequency, Verk.Redis], :ok)
+      expect(Verk.Node, :expire_in, [@verk_node_id, 2 * @frequency, Verk.Redis], {:ok, 1})
       expect(Verk.Node, :queues!, ["dead-node", 0, Verk.Redis], {:more, ["queue_1"], 123})
       expect(Verk.Node, :queues!, ["dead-node", 123, Verk.Redis], {:ok, ["queue_2"]})
 

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -1,6 +1,7 @@
 defmodule Verk.NodeTest do
   use ExUnit.Case
   import Verk.Node
+  doctest Verk.Node
 
   @verk_nodes_key "verk_nodes"
 

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -80,9 +80,9 @@ defmodule Verk.NodeTest do
     end
   end
 
-  describe "expire_in!/3" do
+  describe "expire_in/3" do
     test "resets expiration item", %{redis: redis} do
-      assert expire_in!(@node, 888, redis)
+      assert {:ok, _} = expire_in(@node, 888, redis)
       assert_in_delta Redix.command!(redis, ["PTTL", @node_key]), 888, 5
     end
   end

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -90,10 +90,10 @@ defmodule Verk.NodeTest do
 
   describe "queues!/2" do
     setup %{redis: redis} do
-      add_queue!(@node, "queue_1", redis)
-      add_queue!(@node, "queue_2", redis)
-      add_queue!(@node, "queue_3", redis)
-      add_queue!(@node, "queue_4", redis)
+      Redix.command!(redis, add_queue_redis_command(@node, "queue_1"))
+      Redix.command!(redis, add_queue_redis_command(@node, "queue_2"))
+      Redix.command!(redis, add_queue_redis_command(@node, "queue_3"))
+      Redix.command!(redis, add_queue_redis_command(@node, "queue_4"))
       :ok
     end
 
@@ -101,23 +101,6 @@ defmodule Verk.NodeTest do
       {:ok, queues} = queues!(@node, 0, redis)
       queues = MapSet.new(queues)
       assert MapSet.equal?(queues, MapSet.new(["queue_1", "queue_2", "queue_3", "queue_4"]))
-    end
-  end
-
-  describe "add_queue!/3" do
-    test "add queue to verk:node::queues", %{redis: redis} do
-      queue_name = "default"
-      assert add_queue!(@node, queue_name, redis)
-      assert Redix.command!(redis, ["SMEMBERS", @node_queues_key]) == [queue_name]
-    end
-  end
-
-  describe "remove_queue!/3" do
-    test "remove queue from verk:node::queues", %{redis: redis} do
-      queue_name = "default"
-      assert Redix.command!(redis, ["SADD", @node_queues_key, queue_name]) == 1
-      assert remove_queue!(@node, queue_name, redis)
-      assert Redix.command!(redis, ["SMEMBERS", @node_queues_key]) == []
     end
   end
 end


### PR DESCRIPTION
Here are some changes I made from the original PR #159 

* Change so that `QueueManager` maintains `verk_nodes` and `verk:node:#{node_id}:queues` up-to-date. It avoids possible de-synchronization between Redis and local state of the Verk node. The main idea behind this changes is: "If any job is added to the `inprogress` list, this node and this queue must be tracked so that other nodes can rescue their failure if it happens."
`QueueManager` will conditionally maintain these data structures if `generate_node_id` is true.
* Change `Node.Manager` to not crash if `heartbeat` failed.