### PR TITLE
Change Verk.Supervisor to support treamlined child specs

### DIFF
--- a/lib/verk/supervisor.ex
+++ b/lib/verk/supervisor.ex
@@ -12,7 +12,7 @@ defmodule Verk.Supervisor do
   @doc """
   It starts the main supervisor
   """
-  def start_link do
+  def start_link(_) do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 


### PR DESCRIPTION
Elixir v1.5 allows child specifications, which specify how a child process is supervised, to be defined in modules.

```
children = [
  MyApp.Repo,
  MyApp.Endpoint
]

Supervisor.start_link(children, strategy: :one_for_one)
```
