### PR TITLE
Relax Confex Version - closes #189

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Verk.Mixfile do
       {:redix, "~> 0.8"},
       {:jason, "~> 1.0"},
       {:poolboy, "~> 1.5.1"},
-      {:confex, "~> 3.3.0"},
+      {:confex, "~> 3.3"},
       {:gen_stage, "~> 0.12.1"},
       {:credo, "~> 0.9", only: [:dev, :test]},
       {:earmark, "~> 1.0", only: :dev},


### PR DESCRIPTION
Removes the `.0` version requirement so that confex works with versions later than `3.3`.

