### PR TITLE
Accept a job struct as the argument to perform

### DIFF
--- a/lib/verk/worker.ex
+++ b/lib/verk/worker.ex
@@ -32,7 +32,7 @@ defmodule Verk.Worker do
   @doc false
   def handle_cast({:perform, job, manager}, state) do
     :erlang.put(@process_dict_key, job)
-    [job.class] |> Module.safe_concat() |> apply(:perform, job.args)
+    [job.class] |> Module.safe_concat() |> apply(:perform, job.args ++ [job])
     GenServer.cast(manager, {:done, self(), job.jid})
     {:stop, :normal, state}
   rescue


### PR DESCRIPTION
This allows workers to use any attribute of
the job to customize behaviour, e.g. the number of retries or error message.