### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,8 +297,8 @@ config :verk,
 
 # In some other file
 defmodule MyApp.Env do
-  def verk_queues("true"), do: []
-  def verk_queues(_), do: [default: 25, priority: 10]
+  def verk_queues("true"), do: {:ok, []}
+  def verk_queues(_), do: {:ok, [default: 25, priority: 10]}
 end
 ```
 


### PR DESCRIPTION
According to https://github.com/Nebo15/confex, 

`
Type can be replaced with {module, function, arguments} tuple, in this case Confex will use external function to resolve the type. Function must returns either {:ok, value} or {:error, reason :: String.t} tuple.
`

I modified the readme to prevent misunderstanding 