### PR TITLE
Fix Verk.Job decode/1

### DIFF
--- a/lib/verk/job.ex
+++ b/lib/verk/job.ex
@@ -22,6 +22,8 @@ defmodule Verk.Job do
     max_retry_count: nil
   ]
 
+  @string_keys @keys |> Keyword.keys() |> Enum.map(&Atom.to_string/1)
+
   @type t :: %__MODULE__{
           error_message: String.t(),
           failed_at: DateTime.t(),
@@ -58,6 +60,7 @@ defmodule Verk.Job do
          {:ok, args} <- unwrap_args(map["args"]) do
       fields =
         map
+        |> Map.take(@string_keys)
         |> Map.update!("args", fn _ -> args end)
         |> Map.new(fn {k, v} -> {String.to_existing_atom(k), v} end)
 

--- a/test/job_test.exs
+++ b/test/job_test.exs
@@ -155,6 +155,20 @@ defmodule Verk.JobTest do
                {:ok,
                 %Job{queue: "test_queue", args: [], original_json: payload, max_retry_count: 5}}
     end
+
+    test "discards unknown job attributes" do
+      payload = ~s({ "queue" : "test_queue", "args" : "[1, 2, 3]",
+                   "max_retry_count" : 5, "newrelic": {}})
+
+      assert Job.decode(payload) ==
+               {:ok,
+                %Job{
+                  queue: "test_queue",
+                  args: [1, 2, 3],
+                  original_json: payload,
+                  max_retry_count: 5
+                }}
+    end
   end
 
   describe "default_max_retry_count/0" do


### PR DESCRIPTION
It should only care about `Verk.Job` struct keys discarding any unknown keys.

This is a safer implementation for users that schedule jobs to Verk
using ruby `Sidekiq::Client`.

A recent version of `newrelic_rpm` gem is injecting code into Sidekiq
jobs for some sort of tracing/inspection making jobs scheduled with
`Sidekiq::Client` invalid to Verk as they contain an unknown job key.